### PR TITLE
[21] Rename devkit-import-database to devkit-db-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ There are two types of commands provided by this add-on:
 
 ### `ddev devkit-*` commands
 
-| Command                  | Description                                                |
-| ------------------------ | ---------------------------------------------------------- |
-| `devkit-import-database` | Interactively import an SQL dump into the project database |
-| `devkit-run-script`      | Run a script on the host or in the web container           |
+| Command             | Description                                                |
+| ------------------- | ---------------------------------------------------------- |
+| `devkit-db-import`  | Interactively import an SQL dump into the project database |
+| `devkit-run-script` | Run a script on the host or in the web container           |
 
 ### `ddev site-*` commands
 

--- a/commands/host/devkit-db-import
+++ b/commands/host/devkit-db-import
@@ -3,10 +3,10 @@
 #ddev-generated
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Interactively import an SQL dump into the project database.
-## Usage: devkit-import-database [flags]
-## Example: "ddev devkit-import-database --dir=backups"
+## Usage: devkit-db-import [flags]
+## Example: "ddev devkit-db-import --dir=backups"
 ## Flags: [{"Name":"dir","Usage":"Path to the directory to look for dump files, relative to the project root","Type":"string"}]
-## Aliases: devkit:import-database,devkit-import-db,devkit:import-db
+## Aliases: devkit:db:import,devkit-import-db,devkit:import:db,devkit-database-import,devkit:database:import,devkit-import-database,devkit:import:database
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/install.yaml
+++ b/install.yaml
@@ -1,7 +1,7 @@
 name: site-devkit
 
 project_files:
-  - commands/host/devkit-import-database
+  - commands/host/devkit-db-import
   - commands/host/devkit-run-script
   - commands/host/site-build
   - commands/host/site-build-backend


### PR DESCRIPTION
## The Issue

- Fixes #21

Rename devkit-import-database to devkit-db-import.

## How This PR Solves The Issue

1. Found and replaced code references of ``devkit-import-database`` with `devkit-db-import`.
2. Added additional aliases that would prove to be useful.

## Release/Deployment Notes

1. `devkit-import-database` has been replaced with `devkit-db-import`.
