### PR TITLE
[22] Rename devkit-run-script to devkit-script-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ There are two types of commands provided by this add-on:
 | Command             | Description                                                |
 | ------------------- | ---------------------------------------------------------- |
 | `devkit-db-import`  | Interactively import an SQL dump into the project database |
-| `devkit-run-script` | Run a script on the host or in the web container           |
+| `devkit-script-run` | Run a script on the host or in the web container           |
 
 ### `ddev site-*` commands
 

--- a/commands/host/devkit-script-run
+++ b/commands/host/devkit-script-run
@@ -3,10 +3,10 @@
 #ddev-generated
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Run a script on the host or in the web container.
-## Usage: devkit-run-script [flags] -- [script-args]
-## Example: "ddev devkit-run-script --script=scripts/example.sh --where=web -- script-arg1 script-arg2"
+## Usage: devkit-script-run [flags] -- [script-args]
+## Example: "ddev devkit-script-run --script=scripts/example.sh --where=web -- script-arg1 script-arg2"
 ## Flags: [{"Name":"script","Usage":"Path to the script to run, relative to the project root","Type":"string"},{"Name":"where","Usage":"Where to run the script: 'host' or 'web'","Type":"string"}]
-## Aliases: devkit:run:script,devkit-script-run,devkit:script:run
+## Aliases: devkit:script:run,devkit-run-script,devkit:run:script
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/commands/host/site-build
+++ b/commands/host/site-build
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-run-script --script="$SITE_SCRIPTS/site-build.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-build.sh" --where=host

--- a/commands/host/site-build-backend
+++ b/commands/host/site-build-backend
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-run-script --script="$SITE_SCRIPTS/site-build-backend.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-build-backend.sh" --where=host

--- a/commands/host/site-build-frontend
+++ b/commands/host/site-build-frontend
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-run-script --script="$SITE_SCRIPTS/site-build-frontend.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-build-frontend.sh" --where=host

--- a/commands/host/site-install
+++ b/commands/host/site-install
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-run-script --script="$SITE_SCRIPTS/site-install.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-install.sh" --where=host

--- a/commands/host/site-mode-development
+++ b/commands/host/site-mode-development
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-run-script --script="$SITE_SCRIPTS/site-mode-development.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-mode-development.sh" --where=host

--- a/commands/host/site-mode-production
+++ b/commands/host/site-mode-production
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-run-script --script="$SITE_SCRIPTS/site-mode-production.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-mode-production.sh" --where=host

--- a/commands/host/site-scaffold
+++ b/commands/host/site-scaffold
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-run-script --script="$SITE_SCRIPTS/site-scaffold.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-scaffold.sh" --where=host

--- a/commands/host/site-sync
+++ b/commands/host/site-sync
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-run-script --script="$SITE_SCRIPTS/site-sync.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-sync.sh" --where=host

--- a/commands/host/site-sync-backend
+++ b/commands/host/site-sync-backend
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-run-script --script="$SITE_SCRIPTS/site-sync-backend.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-sync-backend.sh" --where=host

--- a/commands/host/site-sync-frontend
+++ b/commands/host/site-sync-frontend
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-run-script --script="$SITE_SCRIPTS/site-sync-frontend.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-sync-frontend.sh" --where=host

--- a/commands/host/site-test
+++ b/commands/host/site-test
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-run-script --script="$SITE_SCRIPTS/site-test.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-test.sh" --where=host

--- a/commands/host/site-test-backend
+++ b/commands/host/site-test-backend
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-run-script --script="$SITE_SCRIPTS/site-test-backend.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-test-backend.sh" --where=host

--- a/commands/host/site-test-frontend
+++ b/commands/host/site-test-frontend
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-run-script --script="$SITE_SCRIPTS/site-test-frontend.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-test-frontend.sh" --where=host

--- a/install.yaml
+++ b/install.yaml
@@ -2,7 +2,7 @@ name: site-devkit
 
 project_files:
   - commands/host/devkit-db-import
-  - commands/host/devkit-run-script
+  - commands/host/devkit-script-run
   - commands/host/site-build
   - commands/host/site-build-backend
   - commands/host/site-build-frontend


### PR DESCRIPTION
## The Issue

- Fixes #22

Rename devkit-run-script to devkit-script-run.

## How This PR Solves The Issue

1. Found and replaced code references of `devkit-run-script` with `devkit-script-run`.
2. Added additional aliases that would prove to be useful.
3. Updated scripts to use `devkit-script-run` rather than the alias of `devkit-run-script` which may cause confusion.

## Release/Deployment Notes

1. `devkit-run-script` has been replaced with `devkit-script-run`.
