### PR TITLE
[32] New devkit command for creating MinIO buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ There are two types of commands provided by this add-on:
 
 | Command                 | Description                    | Examples                                                                |
 | ----------------------- | ------------------------------ | ----------------------------------------------------------------------- |
-| `site-auth`             | Authentication tasks           | `ddev auth ssh`                                                         |
+| `site-auth`             | Authentication tasks           | Authenticate SSH keys                                                   |
 | `site-build`            | Build tasks                    | `site-build-backend` and `site-build-frontend`                          |
-| `site-build-backend`    | Backend build tasks            | `composer install`                                                      |
-| `site-build-frontend`   | Frontend build tasks           | `npm install`                                                           |
+| `site-build-backend`    | Backend build tasks            | Composer install                                                        |
+| `site-build-frontend`   | Frontend build tasks           | NPM install                                                             |
 | `site-install`          | Installation tasks             | New project installs the application; existing project builds and syncs |
 | `site-mode-development` | Enable development mode        | Disable caches, enable verbose logging                                  |
 | `site-mode-production`  | Enable production mode         | Enable caches, aggregate CSS and JS                                     |

--- a/README.md
+++ b/README.md
@@ -48,17 +48,17 @@ There are two types of commands provided by this add-on:
 | Command                 | Description                    | Examples                                                                |
 | ----------------------- | ------------------------------ | ----------------------------------------------------------------------- |
 | `site-auth`             | Authentication tasks           | Authenticate SSH keys                                                   |
-| `site-build`            | Build tasks                    | `site-build-backend` and `site-build-frontend`                          |
+| `site-build`            | Build tasks                    | Wraps tasks for the backend and frontend                                |
 | `site-build-backend`    | Backend build tasks            | Composer install                                                        |
 | `site-build-frontend`   | Frontend build tasks           | NPM install                                                             |
 | `site-install`          | Installation tasks             | New project installs the application; existing project builds and syncs |
 | `site-mode-development` | Enable development mode        | Disable caches, enable verbose logging                                  |
 | `site-mode-production`  | Enable production mode         | Enable caches, aggregate CSS and JS                                     |
 | `site-scaffold`         | Scaffolding tasks              | Copy required files, set permissions                                    |
-| `site-sync`             | Synchronisation tasks          | `site-sync-backend` and `site-sync-frontend`                            |
+| `site-sync`             | Synchronisation tasks          | Wraps tasks for the backend and frontend                                |
 | `site-sync-backend`     | Backend synchronisation tasks  | Database import, public files                                           |
 | `site-sync-frontend`    | Frontend synchronisation tasks | Images, compiled CSS and JS                                             |
-| `site-test`             | Testing tasks                  | `site-test-backend` and `site-test-frontend`                            |
+| `site-test`             | Testing tasks                  | Wraps tasks for the backend and frontend                                |
 | `site-test-backend`     | Backend testing tasks          | Unit, kernel, integration                                               |
 | `site-test-frontend`    | Frontend testing tasks         | Unit, end to end                                                        |
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ There are two types of commands provided by this add-on:
 
 ### `ddev devkit-*` commands
 
-| Command             | Description                                                |
-| ------------------- | ---------------------------------------------------------- |
-| `devkit-db-import`  | Interactively import an SQL dump into the project database |
-| `devkit-script-run` | Run a script on the host or in the web container           |
+| Command                      | Description                                                    |
+| ---------------------------- | -------------------------------------------------------------- |
+| `devkit-db-import`           | Interactively import an SQL dump into the project database     |
+| `devkit-minio-create-bucket` | Create a MinIO bucket if it does not exist, and set its policy |
+| `devkit-script-run`          | Run a script on the host or in the web container               |
 
 ### `ddev site-*` commands
 

--- a/commands/host/devkit-minio-create-bucket
+++ b/commands/host/devkit-minio-create-bucket
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/colinstillwell/ddev-site-devkit
+## Description: Create a MinIO bucket if it does not exist, and set its policy.
+## Usage: devkit-minio-create-bucket [flags]
+## Example: "ddev devkit-minio-create-bucket --bucket=example --policy=public"
+## Flags: [{"Name":"bucket","Usage":"Name of the bucket to create","Type":"string"},{"Name":"policy","Usage":"Policy to set on the bucket","Type":"string"},{"Name":"access-key","Usage":"Access key for MinIO","Type":"string"},{"Name":"secret-key","Usage":"Secret key for MinIO","Type":"string"},{"Name":"host","Usage":"Host URL for MinIO","Type":"string"}]
+## Aliases: devkit:minio:create:bucket,devkit-minio-bucket-create,devkit:minio:bucket:create
+
+# Exit on error; treat unset variables as errors; fail pipelines if any command fails
+set -euo pipefail
+
+# Defaults
+BUCKET=""
+POLICY=""
+ACCESS_KEY="ddevminio"
+SECRET_KEY="ddevminio"
+HOST="$DDEV_PRIMARY_URL_WITHOUT_PORT:10101"
+
+# Parse flags
+for ARG in "$@"; do
+  case "$ARG" in
+    --bucket=*) BUCKET="${ARG#*=}"; shift; continue ;;
+    --policy=*) POLICY="${ARG#*=}"; shift; continue ;;
+    --access-key=*) ACCESS_KEY="${ARG#*=}"; shift; continue ;;
+    --secret-key=*) SECRET_KEY="${ARG#*=}"; shift; continue ;;
+    --host=*) HOST="${ARG#*=}"; shift; continue ;;
+    *) echo "Unknown flag: $ARG"; exit 2 ;;
+  esac
+done
+
+# Validate
+[[ -n "$BUCKET" ]] || { echo "--bucket is required."; exit 2; }
+[[ -n "$POLICY" ]] || { echo "--policy is required."; exit 2; }
+
+# Summarise
+echo "Creating '$BUCKET' bucket with '$POLICY' policy if it does not exist..."
+
+# Commands
+mc_exec() {
+  ddev exec -s minio env MC_CONFIG_DIR=/tmp/.mc mc --insecure "$@"
+}
+
+mc_exec alias set localminio "$HOST" "$ACCESS_KEY" "$SECRET_KEY" > /dev/null
+
+if mc_exec ls localminio | grep -q "^.* $BUCKET/"; then
+  echo "Bucket '$BUCKET' already exists. Skipping creation."
+else
+  echo "Bucket '$BUCKET' does not exist. Creating it..."
+  mc_exec mb "localminio/$BUCKET" > /dev/null
+
+  echo "Setting public policy on '$BUCKET'..."
+  mc_exec anonymous set public "localminio/$BUCKET" > /dev/null
+fi

--- a/install.yaml
+++ b/install.yaml
@@ -2,6 +2,7 @@ name: site-devkit
 
 project_files:
   - commands/host/devkit-db-import
+  - commands/host/devkit-minio-create-bucket
   - commands/host/devkit-script-run
   - commands/host/site-auth
   - commands/host/site-build


### PR DESCRIPTION
## The Issue

- Fixes #32

New devkit command for creating MinIO buckets.

## How This PR Solves The Issue

1. Created the command.
2. Updated the README.
3. Updated the `install.yaml` to copy the new file.

## Release/Deployment Notes

1. Introduced a new `devkit-minio-create-bucket` command.

