### PR TITLE
[31] New devkit command for getting variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ There are two types of commands provided by this add-on:
 | `devkit-db-import`           | Interactively import an SQL dump into the project database     |
 | `devkit-minio-create-bucket` | Create a MinIO bucket if it does not exist, and set its policy |
 | `devkit-script-run`          | Run a script on the host or in the web container               |
+| `devkit-var-get`             | Get the value of a variable from the specified source          |
 
 ### `ddev site-*` commands
 

--- a/commands/host/devkit-var-get
+++ b/commands/host/devkit-var-get
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/colinstillwell/ddev-site-devkit
+## Description: Get the value of a variable from the specified source.
+## Usage: devkit-var-get [flags]
+## Example: "ddev devkit-var-get --name=EXAMPLE --source=env"
+## Flags: [{"Name":"name","Usage":"The name of the variable to get the value for","Type":"string"},{"Name":"source","Usage":"The source to get the variable from","Type":"string"}]
+## Aliases: devkit:var:get,devkit-get-var,devkit:get:var
+
+# Exit on error; treat unset variables as errors; fail pipelines if any command fails
+set -euo pipefail
+
+# Defaults
+NAME=""
+SOURCE=""
+
+# Parse flags
+for ARG in "$@"; do
+  case "$ARG" in
+    --name=*) NAME="${ARG#*=}"; shift; continue ;;
+    --source=*) SOURCE="${ARG#*=}"; shift; continue ;;
+    *) echo "Unknown flag: $ARG"; exit 2 ;;
+  esac
+done
+
+# Validate
+[[ -n "$NAME" ]] || { echo "--name is required."; exit 2; }
+[[ -n "$SOURCE" ]] || { echo "--source is required."; exit 2; }
+
+if [[ "$SOURCE" != "env" ]]; then
+  echo "Unsupported --source '$SOURCE'. Only 'env' is supported." >&2
+  exit 2
+fi
+
+# Commands
+VALUE="$(ddev exec bash -lc "printenv $(printf '%q' "$NAME")" 2>/dev/null || true)"
+
+if [[ -z "$VALUE" ]]; then
+  exit 1
+fi
+
+printf '%s\n' "$VALUE"

--- a/install.yaml
+++ b/install.yaml
@@ -4,6 +4,7 @@ project_files:
   - commands/host/devkit-db-import
   - commands/host/devkit-minio-create-bucket
   - commands/host/devkit-script-run
+  - commands/host/devkit-var-get
   - commands/host/site-auth
   - commands/host/site-build
   - commands/host/site-build-backend


### PR DESCRIPTION
## The Issue

- Fixes #31

New devkit command for getting variables.

## How This PR Solves The Issue

1. Created the command.
2. Updated the README.
3. Updated the `install.yaml` to copy the new file.

## Release/Deployment Notes

1. Introduced a new `devkit-var-get` command.

