### PR TITLE
[38] Update devkit-script-run to use --location instead of --where

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ There are two types of commands provided by this add-on:
 | ---------------------------- | ------------------------------------------------------------------ |
 | `devkit-db-import`           | Interactively import an SQL dump into the project database         |
 | `devkit-minio-create-bucket` | Create a MinIO bucket if it does not exist, and set its policy     |
-| `devkit-script-run`          | Run a script on the host or in the web container                   |
+| `devkit-script-run`          | Run a script on the host or in a specified service                 |
 | `devkit-var-get`             | Get the value of a variable from the specified format and location |
 
 ### `ddev site-*` commands

--- a/commands/host/devkit-script-run
+++ b/commands/host/devkit-script-run
@@ -2,10 +2,10 @@
 
 #ddev-generated
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
-## Description: Run a script on the host or in the web container.
+## Description: Run a script on the host or in a specified service.
 ## Usage: devkit-script-run [flags] -- [script-args]
-## Example: "ddev devkit-script-run --script=scripts/example.sh --where=web -- script-arg1 script-arg2"
-## Flags: [{"Name":"script","Usage":"Path to the script to run, relative to the project root","Type":"string"},{"Name":"where","Usage":"Where to run the script: 'host' or 'web'","Type":"string"}]
+## Example: "ddev devkit-script-run --script=scripts/example.sh --location=web -- script-arg1 script-arg2"
+## Flags: [{"Name":"script","Usage":"Path to the script to run, relative to the project root","Type":"string"},{"Name":"location","Usage":"Where to run the script: 'host' or a service name such as 'web'","Type":"string"}]
 ## Aliases: devkit:script:run,devkit-run-script,devkit:run:script
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
@@ -13,13 +13,13 @@ set -euo pipefail
 
 # Defaults
 SCRIPT=""
-WHERE="host"
+LOCATION=""
 
 # Parse flags
 for ARG in "$@"; do
   case "$ARG" in
     --script=*) SCRIPT="${ARG#*=}"; shift; continue ;;
-    --where=*) WHERE="${ARG#*=}"; shift; continue ;;
+    --location=*) LOCATION="${ARG#*=}"; shift; continue ;;
     --) shift; break ;;
     *) echo "Unknown flag: $ARG"; exit 2 ;;
   esac
@@ -27,19 +27,20 @@ done
 
 # Validate
 [[ -n "$SCRIPT" ]] || { echo "--script is required."; exit 2; }
+[[ -n "$LOCATION" ]] || { echo "--location is required."; exit 2; }
 
-if [[ "$WHERE" == host ]]; then
+if [[ "$LOCATION" == host ]]; then
   SCRIPT_PATH="$DDEV_APPROOT/$SCRIPT"
 else
   SCRIPT_PATH="$SCRIPT"
 fi
 
 # Summarise
-echo "Running script '$SCRIPT' in '$WHERE'..."
+echo "Running script '$SCRIPT' in '$LOCATION'..."
 
 # Commands
-if [[ "$WHERE" == host ]]; then
+if [[ "$LOCATION" == host ]]; then
   exec bash "$SCRIPT_PATH" "$@"
 else
-  exec ddev exec bash "$SCRIPT_PATH" "$@"
+  exec ddev exec -s "$LOCATION" bash "$SCRIPT_PATH" "$@"
 fi

--- a/commands/host/site-auth
+++ b/commands/host/site-auth
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-auth.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-auth.sh" --location=host

--- a/commands/host/site-build
+++ b/commands/host/site-build
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-build.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-build.sh" --location=host

--- a/commands/host/site-build-backend
+++ b/commands/host/site-build-backend
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-build-backend.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-build-backend.sh" --location=host

--- a/commands/host/site-build-frontend
+++ b/commands/host/site-build-frontend
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-build-frontend.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-build-frontend.sh" --location=host

--- a/commands/host/site-install
+++ b/commands/host/site-install
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-install.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-install.sh" --location=host

--- a/commands/host/site-mode-development
+++ b/commands/host/site-mode-development
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-mode-development.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-mode-development.sh" --location=host

--- a/commands/host/site-mode-production
+++ b/commands/host/site-mode-production
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-mode-production.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-mode-production.sh" --location=host

--- a/commands/host/site-scaffold
+++ b/commands/host/site-scaffold
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-scaffold.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-scaffold.sh" --location=host

--- a/commands/host/site-sync
+++ b/commands/host/site-sync
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-sync.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-sync.sh" --location=host

--- a/commands/host/site-sync-backend
+++ b/commands/host/site-sync-backend
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-sync-backend.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-sync-backend.sh" --location=host

--- a/commands/host/site-sync-frontend
+++ b/commands/host/site-sync-frontend
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-sync-frontend.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-sync-frontend.sh" --location=host

--- a/commands/host/site-test
+++ b/commands/host/site-test
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-test.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-test.sh" --location=host

--- a/commands/host/site-test-backend
+++ b/commands/host/site-test-backend
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-test-backend.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-test-backend.sh" --location=host

--- a/commands/host/site-test-frontend
+++ b/commands/host/site-test-frontend
@@ -14,4 +14,4 @@ set -euo pipefail
 SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
 
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-test-frontend.sh" --where=host
+ddev devkit-script-run --script="$SITE_SCRIPTS/site-test-frontend.sh" --location=host


### PR DESCRIPTION
## The Issue

- Fixes #38

Update devkit-script-run to use --location instead of --where.

## How This PR Solves The Issue

1. Replaced `--where` with `--location`.
2. Updated command help text, usage examples, and flag metadata.

## Release/Deployment Notes

1. `devkit-script-run` expects `--location` instead of `--where`.
2. `--location` is now also required.
