### PR TITLE
[5] New devkit command for copying files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ There are two types of commands provided by this add-on:
 
 ### `ddev devkit-*` commands
 
-| Command                      | Description                                                        |
-| ---------------------------- | ------------------------------------------------------------------ |
-| `devkit-db-import`           | Interactively import an SQL dump into the project database         |
-| `devkit-minio-create-bucket` | Create a MinIO bucket if it does not exist, and set its policy     |
-| `devkit-script-run`          | Run a script on the host or in a specified service                 |
-| `devkit-var-get`             | Get the value of a variable from the specified format and location |
+| Command                      | Description                                                                              |
+| ---------------------------- | ---------------------------------------------------------------------------------------- |
+| `devkit-db-import`           | Interactively import an SQL dump into the project database                               |
+| `devkit-file-copy`           | Copy a file from source to destination within the project, skipping if it already exists |
+| `devkit-minio-create-bucket` | Create a MinIO bucket if it does not exist, and set its policy                           |
+| `devkit-script-run`          | Run a script on the host or in a specified service                                       |
+| `devkit-var-get`             | Get the value of a variable from the specified format and location                       |
 
 ### `ddev site-*` commands
 

--- a/commands/host/devkit-db-import
+++ b/commands/host/devkit-db-import
@@ -25,7 +25,7 @@ done
 # Validate
 DIRECTORY_PATH="$DDEV_APPROOT/$DIRECTORY"
 
-[[ -d "$DIRECTORY_PATH" ]] || { echo "'$DIRECTORY_PATH' not found."; exit 1; }
+[[ -d "$DIRECTORY_PATH" ]] || { echo "Directory not found. Cannot locate dump files in '$DIRECTORY_PATH'."; exit 1; }
 
 shopt -s nullglob
 FILES=(
@@ -44,7 +44,7 @@ FILES=(
 )
 shopt -u nullglob
 
-(( ${#FILES[@]} > 0 )) || { echo "No dump files found in '$DIRECTORY_PATH'."; exit 1; }
+(( ${#FILES[@]} > 0 )) || { echo "Cannot locate dump files in '$DIRECTORY_PATH'."; exit 1; }
 
 # Prompt
 echo "Choose a dump file to import from '$DIRECTORY_PATH':"

--- a/commands/host/devkit-db-import
+++ b/commands/host/devkit-db-import
@@ -52,7 +52,7 @@ if (( ${#FILES[@]} == 0 )); then
   exit 1
 fi
 
-# Prompt
+# Prompts
 echo "Choose a dump file to import from '$DIRECTORY_PATH':"
 for i in "${!FILES[@]}"; do
   printf "%2d) %s\n" $((i+1)) "$(basename -- "${FILES[$i]}")"

--- a/commands/host/devkit-db-import
+++ b/commands/host/devkit-db-import
@@ -25,7 +25,7 @@ done
 # Validate
 DIRECTORY_PATH="$DDEV_APPROOT/$DIRECTORY"
 
-[[ -d "$DIRECTORY_PATH" ]] || { echo "Folder not found: $DIRECTORY_PATH"; exit 1; }
+[[ -d "$DIRECTORY_PATH" ]] || { echo "'$DIRECTORY_PATH' not found."; exit 1; }
 
 shopt -s nullglob
 FILES=(
@@ -44,10 +44,10 @@ FILES=(
 )
 shopt -u nullglob
 
-(( ${#FILES[@]} > 0 )) || { echo "No dump files found in $DIRECTORY_PATH"; exit 1; }
+(( ${#FILES[@]} > 0 )) || { echo "No dump files found in '$DIRECTORY_PATH'."; exit 1; }
 
 # Prompt
-echo "Choose a dump file to import from: $DIRECTORY_PATH"
+echo "Choose a dump file to import from '$DIRECTORY_PATH':"
 for i in "${!FILES[@]}"; do
   printf "%2d) %s\n" $((i+1)) "$(basename -- "${FILES[$i]}")"
 done

--- a/commands/host/devkit-db-import
+++ b/commands/host/devkit-db-import
@@ -4,8 +4,8 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Interactively import an SQL dump into the project database.
 ## Usage: devkit-db-import [flags]
-## Example: "ddev devkit-db-import --dir=backups"
-## Flags: [{"Name":"dir","Usage":"Path to the directory to look for dump files, relative to the project root","Type":"string"}]
+## Example: "ddev devkit-db-import --directory=backups"
+## Flags: [{"Name":"directory","Usage":"Path to the directory to look for dump files, relative to the project root","Type":"string"}]
 ## Aliases: devkit:db:import,devkit-import-db,devkit:import:db,devkit-database-import,devkit:database:import,devkit-import-database,devkit:import:database
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
@@ -17,7 +17,8 @@ DIRECTORY="database"
 # Parse flags
 for ARG in "$@"; do
   case "$ARG" in
-    --dir=*) DIRECTORY="${ARG#*=}"; shift; continue ;;
+    --directory=*) DIRECTORY="${ARG#*=}"; shift; continue ;;
+    --dir=*)       DIRECTORY="${ARG#*=}"; shift; continue ;;
     *) echo "Unknown flag: $ARG"; exit 2 ;;
   esac
 done

--- a/commands/host/devkit-db-import
+++ b/commands/host/devkit-db-import
@@ -61,8 +61,6 @@ while true; do
   echo "Invalid selection. Please try again."
 done
 
-# Summarise
-echo "Importing dump file '$(basename -- "$CHOICE")'..."
-
 # Commands
+echo "Importing dump file '$(basename -- "$CHOICE")'..."
 exec ddev import-db -f "$CHOICE"

--- a/commands/host/devkit-db-import
+++ b/commands/host/devkit-db-import
@@ -22,10 +22,13 @@ for ARG in "$@"; do
   esac
 done
 
-# Validate
+# Guards
 DIRECTORY_PATH="$DDEV_APPROOT/$DIRECTORY"
 
-[[ -d "$DIRECTORY_PATH" ]] || { echo "Directory not found. Cannot locate dump files in '$DIRECTORY_PATH'."; exit 1; }
+if [[ ! -d "$DIRECTORY_PATH" ]]; then
+  echo "Directory not found. Cannot locate dump files in '$DIRECTORY_PATH'."
+  exit 1
+fi
 
 shopt -s nullglob
 FILES=(
@@ -44,7 +47,10 @@ FILES=(
 )
 shopt -u nullglob
 
-(( ${#FILES[@]} > 0 )) || { echo "Cannot locate dump files in '$DIRECTORY_PATH'."; exit 1; }
+if (( ${#FILES[@]} == 0 )); then
+  echo "Cannot locate dump files in '$DIRECTORY_PATH'."
+  exit 1
+fi
 
 # Prompt
 echo "Choose a dump file to import from '$DIRECTORY_PATH':"

--- a/commands/host/devkit-file-copy
+++ b/commands/host/devkit-file-copy
@@ -19,7 +19,9 @@ DESTINATION=""
 for ARG in "$@"; do
   case "$ARG" in
     --source=*)      SOURCE="${ARG#*=}"; shift; continue ;;
+    --src=*)         SOURCE="${ARG#*=}"; shift; continue ;;
     --destination=*) DESTINATION="${ARG#*=}"; shift; continue ;;
+    --dest=*)        DESTINATION="${ARG#*=}"; shift; continue ;;
     *) echo "Unknown flag: $ARG"; exit 2 ;;
   esac
 done

--- a/commands/host/devkit-file-copy
+++ b/commands/host/devkit-file-copy
@@ -33,10 +33,31 @@ done
 # Guards
 SOURCE_PATH="$DDEV_APPROOT/$SOURCE"
 DESTINATION_PATH="$DDEV_APPROOT/$DESTINATION"
+DESTINATION_DIR="$(dirname "$DESTINATION_PATH")"
+
+if [[ -d "$SOURCE_PATH" ]]; then
+  echo "'$SOURCE_PATH' is a directory. Refusing to copy to '$DESTINATION_PATH'."
+  exit 1
+fi
+
+if [[ -d "$DESTINATION_PATH" ]]; then
+  echo "'$DESTINATION_PATH' is a directory. Refusing to overwrite a directory with a file."
+  exit 1
+fi
+
+if [[ ! -d "$DESTINATION_DIR" ]]; then
+  echo "Destination directory '$DESTINATION_DIR' not found. Cannot copy to '$DESTINATION_PATH'."
+  exit 1
+fi
 
 if [[ ! -f "$SOURCE_PATH" ]]; then
   echo "'$SOURCE_PATH' not found. Cannot copy to '$DESTINATION_PATH'."
   exit 1
+fi
+
+if [[ -e "$DESTINATION_PATH" ]] && [[ "$SOURCE_PATH" -ef "$DESTINATION_PATH" ]]; then
+  echo "'$SOURCE_PATH' and '$DESTINATION_PATH' refer to the same file. Nothing to do."
+  exit 0
 fi
 
 if [[ -f "$DESTINATION_PATH" ]]; then

--- a/commands/host/devkit-file-copy
+++ b/commands/host/devkit-file-copy
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/colinstillwell/ddev-site-devkit
+## Description: Copy a file from source to destination within the project, skipping if it already exists.
+## Usage: devkit-file-copy [flags]
+## Example: "ddev devkit-file-copy --source=.env.example --destination=.env"
+## Flags: [{"Name":"source","Usage":"Path to the file to copy, relative to the project root","Type":"string"},{"Name":"destination","Usage":"Path to copy the file to, relative to the project root","Type":"string"}]
+## Aliases: devkit:file:copy,devkit-copy-file,devkit:copy:file
+
+# Exit on error; treat unset variables as errors; fail pipelines if any command fails
+set -euo pipefail
+
+# Defaults
+SOURCE=""
+DESTINATION=""
+
+# Parse flags
+for ARG in "$@"; do
+  case "$ARG" in
+    --source=*) SOURCE="${ARG#*=}"; shift; continue ;;
+    --destination=*) DESTINATION="${ARG#*=}"; shift; continue ;;
+    *) echo "Unknown flag: $ARG"; exit 2 ;;
+  esac
+done
+
+# Validate
+[[ -n "$SOURCE" ]] || { echo "--source is required."; exit 2; }
+[[ -n "$DESTINATION" ]] || { echo "--destination is required."; exit 2; }
+
+# Commands
+SOURCE_PATH="$DDEV_APPROOT/$SOURCE"
+DESTINATION_PATH="$DDEV_APPROOT/$DESTINATION"
+
+if [[ -f "$DESTINATION_PATH" ]]; then
+  echo "'$DESTINATION_PATH' already exists, skipping."
+elif [[ -f "$SOURCE_PATH" ]]; then
+  echo "Copying '$SOURCE_PATH' to '$DESTINATION_PATH'."
+  cp "$SOURCE_PATH" "$DESTINATION_PATH"
+else
+  echo "'$SOURCE_PATH' not found. Cannot copy to '$DESTINATION_PATH'."
+  exit 1
+fi

--- a/commands/host/devkit-file-copy
+++ b/commands/host/devkit-file-copy
@@ -26,7 +26,7 @@ for ARG in "$@"; do
   esac
 done
 
-# Validate
+# Validate flags
 [[ -n "$SOURCE" ]] || { echo "--source is required."; exit 2; }
 [[ -n "$DESTINATION" ]] || { echo "--destination is required."; exit 2; }
 

--- a/commands/host/devkit-file-copy
+++ b/commands/host/devkit-file-copy
@@ -38,9 +38,9 @@ if [[ ! -f "$SOURCE_PATH" ]]; then
 fi
 
 if [[ -f "$DESTINATION_PATH" ]]; then
-  echo "'$DESTINATION_PATH' already exists, skipping."
+  echo "'$DESTINATION_PATH' already exists. Nothing to do."
   exit 0
 fi
 
-echo "Copying '$SOURCE_PATH' to '$DESTINATION_PATH'."
+echo "Copying '$SOURCE_PATH' to '$DESTINATION_PATH'..."
 cp "$SOURCE_PATH" "$DESTINATION_PATH"

--- a/commands/host/devkit-file-copy
+++ b/commands/host/devkit-file-copy
@@ -18,7 +18,7 @@ DESTINATION=""
 # Parse flags
 for ARG in "$@"; do
   case "$ARG" in
-    --source=*) SOURCE="${ARG#*=}"; shift; continue ;;
+    --source=*)      SOURCE="${ARG#*=}"; shift; continue ;;
     --destination=*) DESTINATION="${ARG#*=}"; shift; continue ;;
     *) echo "Unknown flag: $ARG"; exit 2 ;;
   esac

--- a/commands/host/devkit-file-copy
+++ b/commands/host/devkit-file-copy
@@ -32,12 +32,15 @@ done
 SOURCE_PATH="$DDEV_APPROOT/$SOURCE"
 DESTINATION_PATH="$DDEV_APPROOT/$DESTINATION"
 
-if [[ -f "$DESTINATION_PATH" ]]; then
-  echo "'$DESTINATION_PATH' already exists, skipping."
-elif [[ -f "$SOURCE_PATH" ]]; then
-  echo "Copying '$SOURCE_PATH' to '$DESTINATION_PATH'."
-  cp "$SOURCE_PATH" "$DESTINATION_PATH"
-else
+if [[ ! -f "$SOURCE_PATH" ]]; then
   echo "'$SOURCE_PATH' not found. Cannot copy to '$DESTINATION_PATH'."
   exit 1
 fi
+
+if [[ -f "$DESTINATION_PATH" ]]; then
+  echo "'$DESTINATION_PATH' already exists, skipping."
+  exit 0
+fi
+
+echo "Copying '$SOURCE_PATH' to '$DESTINATION_PATH'."
+cp "$SOURCE_PATH" "$DESTINATION_PATH"

--- a/commands/host/devkit-file-copy
+++ b/commands/host/devkit-file-copy
@@ -28,7 +28,7 @@ done
 [[ -n "$SOURCE" ]] || { echo "--source is required."; exit 2; }
 [[ -n "$DESTINATION" ]] || { echo "--destination is required."; exit 2; }
 
-# Commands
+# Guards
 SOURCE_PATH="$DDEV_APPROOT/$SOURCE"
 DESTINATION_PATH="$DDEV_APPROOT/$DESTINATION"
 
@@ -42,5 +42,6 @@ if [[ -f "$DESTINATION_PATH" ]]; then
   exit 0
 fi
 
+# Commands
 echo "Copying '$SOURCE_PATH' to '$DESTINATION_PATH'..."
 cp "$SOURCE_PATH" "$DESTINATION_PATH"

--- a/commands/host/devkit-minio-create-bucket
+++ b/commands/host/devkit-minio-create-bucket
@@ -42,13 +42,15 @@ mc_exec() {
 # Aliases
 mc_exec alias set localminio "$HOST" "$ACCESS_KEY" "$SECRET_KEY" > /dev/null
 
-# Commands
+# Guards
 if mc_exec ls localminio | grep -q "^.* $BUCKET/"; then
   echo "MinIO bucket '$BUCKET' already exists. Nothing to do."
-else
-  echo "Creating MinIO bucket '$BUCKET'..."
-  mc_exec mb "localminio/$BUCKET" > /dev/null
-
-  echo "Setting policy '$POLICY' on MinIO bucket '$BUCKET'..."
-  mc_exec anonymous set public "localminio/$BUCKET" > /dev/null
+  exit 0
 fi
+
+# Commands
+echo "Creating MinIO bucket '$BUCKET'..."
+mc_exec mb "localminio/$BUCKET" > /dev/null
+
+echo "Setting policy '$POLICY' on MinIO bucket '$BUCKET'..."
+mc_exec anonymous set public "localminio/$BUCKET" > /dev/null

--- a/commands/host/devkit-minio-create-bucket
+++ b/commands/host/devkit-minio-create-bucket
@@ -34,13 +34,15 @@ done
 [[ -n "$BUCKET" ]] || { echo "--bucket is required."; exit 2; }
 [[ -n "$POLICY" ]] || { echo "--policy is required."; exit 2; }
 
-# Commands
+# Helpers
 mc_exec() {
   ddev exec -s minio env MC_CONFIG_DIR=/tmp/.mc mc --insecure "$@"
 }
 
+# Aliases
 mc_exec alias set localminio "$HOST" "$ACCESS_KEY" "$SECRET_KEY" > /dev/null
 
+# Commands
 if mc_exec ls localminio | grep -q "^.* $BUCKET/"; then
   echo "MinIO bucket '$BUCKET' already exists. Nothing to do."
 else

--- a/commands/host/devkit-minio-create-bucket
+++ b/commands/host/devkit-minio-create-bucket
@@ -34,10 +34,8 @@ done
 [[ -n "$BUCKET" ]] || { echo "--bucket is required."; exit 2; }
 [[ -n "$POLICY" ]] || { echo "--policy is required."; exit 2; }
 
-# Summarise
-echo "Creating '$BUCKET' bucket with '$POLICY' policy if it does not exist..."
-
 # Commands
+echo "Creating '$BUCKET' bucket with '$POLICY' policy if it does not exist..."
 mc_exec() {
   ddev exec -s minio env MC_CONFIG_DIR=/tmp/.mc mc --insecure "$@"
 }

--- a/commands/host/devkit-minio-create-bucket
+++ b/commands/host/devkit-minio-create-bucket
@@ -30,7 +30,7 @@ for ARG in "$@"; do
   esac
 done
 
-# Validate
+# Validate flags
 [[ -n "$BUCKET" ]] || { echo "--bucket is required."; exit 2; }
 [[ -n "$POLICY" ]] || { echo "--policy is required."; exit 2; }
 

--- a/commands/host/devkit-minio-create-bucket
+++ b/commands/host/devkit-minio-create-bucket
@@ -21,11 +21,11 @@ HOST="$DDEV_PRIMARY_URL_WITHOUT_PORT:10101"
 # Parse flags
 for ARG in "$@"; do
   case "$ARG" in
-    --bucket=*) BUCKET="${ARG#*=}"; shift; continue ;;
-    --policy=*) POLICY="${ARG#*=}"; shift; continue ;;
+    --bucket=*)     BUCKET="${ARG#*=}"; shift; continue ;;
+    --policy=*)     POLICY="${ARG#*=}"; shift; continue ;;
     --access-key=*) ACCESS_KEY="${ARG#*=}"; shift; continue ;;
     --secret-key=*) SECRET_KEY="${ARG#*=}"; shift; continue ;;
-    --host=*) HOST="${ARG#*=}"; shift; continue ;;
+    --host=*)       HOST="${ARG#*=}"; shift; continue ;;
     *) echo "Unknown flag: $ARG"; exit 2 ;;
   esac
 done

--- a/commands/host/devkit-minio-create-bucket
+++ b/commands/host/devkit-minio-create-bucket
@@ -35,7 +35,6 @@ done
 [[ -n "$POLICY" ]] || { echo "--policy is required."; exit 2; }
 
 # Commands
-echo "Creating '$BUCKET' bucket with '$POLICY' policy if it does not exist..."
 mc_exec() {
   ddev exec -s minio env MC_CONFIG_DIR=/tmp/.mc mc --insecure "$@"
 }
@@ -43,11 +42,11 @@ mc_exec() {
 mc_exec alias set localminio "$HOST" "$ACCESS_KEY" "$SECRET_KEY" > /dev/null
 
 if mc_exec ls localminio | grep -q "^.* $BUCKET/"; then
-  echo "Bucket '$BUCKET' already exists. Skipping creation."
+  echo "MinIO bucket '$BUCKET' already exists. Nothing to do."
 else
-  echo "Bucket '$BUCKET' does not exist. Creating it..."
+  echo "Creating MinIO bucket '$BUCKET'..."
   mc_exec mb "localminio/$BUCKET" > /dev/null
 
-  echo "Setting public policy on '$BUCKET'..."
+  echo "Setting policy '$POLICY' on MinIO bucket '$BUCKET'..."
   mc_exec anonymous set public "localminio/$BUCKET" > /dev/null
 fi

--- a/commands/host/devkit-script-run
+++ b/commands/host/devkit-script-run
@@ -29,16 +29,16 @@ done
 [[ -n "$SCRIPT" ]] || { echo "--script is required."; exit 2; }
 [[ -n "$LOCATION" ]] || { echo "--location is required."; exit 2; }
 
+# Summarise
+echo "Running script '$SCRIPT' in '$LOCATION'..."
+
+# Commands
 if [[ "$LOCATION" == host ]]; then
   SCRIPT_PATH="$DDEV_APPROOT/$SCRIPT"
 else
   SCRIPT_PATH="$SCRIPT"
 fi
 
-# Summarise
-echo "Running script '$SCRIPT' in '$LOCATION'..."
-
-# Commands
 if [[ "$LOCATION" == host ]]; then
   exec bash "$SCRIPT_PATH" "$@"
 else

--- a/commands/host/devkit-script-run
+++ b/commands/host/devkit-script-run
@@ -29,13 +29,14 @@ done
 [[ -n "$SCRIPT" ]] || { echo "--script is required."; exit 2; }
 [[ -n "$LOCATION" ]] || { echo "--location is required."; exit 2; }
 
-# Commands
+# Guards
 if [[ "$LOCATION" == host ]]; then
   SCRIPT_PATH="$DDEV_APPROOT/$SCRIPT"
 else
   SCRIPT_PATH="$SCRIPT"
 fi
 
+# Commands
 echo "Running script '$SCRIPT' in '$LOCATION'..."
 if [[ "$LOCATION" == host ]]; then
   exec bash "$SCRIPT_PATH" "$@"

--- a/commands/host/devkit-script-run
+++ b/commands/host/devkit-script-run
@@ -29,9 +29,6 @@ done
 [[ -n "$SCRIPT" ]] || { echo "--script is required."; exit 2; }
 [[ -n "$LOCATION" ]] || { echo "--location is required."; exit 2; }
 
-# Summarise
-echo "Running script '$SCRIPT' in '$LOCATION'..."
-
 # Commands
 if [[ "$LOCATION" == host ]]; then
   SCRIPT_PATH="$DDEV_APPROOT/$SCRIPT"
@@ -39,6 +36,7 @@ else
   SCRIPT_PATH="$SCRIPT"
 fi
 
+echo "Running script '$SCRIPT' in '$LOCATION'..."
 if [[ "$LOCATION" == host ]]; then
   exec bash "$SCRIPT_PATH" "$@"
 else

--- a/commands/host/devkit-script-run
+++ b/commands/host/devkit-script-run
@@ -25,7 +25,7 @@ for ARG in "$@"; do
   esac
 done
 
-# Validate
+# Validate flags
 [[ -n "$SCRIPT" ]] || { echo "--script is required."; exit 2; }
 [[ -n "$LOCATION" ]] || { echo "--location is required."; exit 2; }
 

--- a/commands/host/devkit-script-run
+++ b/commands/host/devkit-script-run
@@ -18,7 +18,7 @@ LOCATION=""
 # Parse flags
 for ARG in "$@"; do
   case "$ARG" in
-    --script=*) SCRIPT="${ARG#*=}"; shift; continue ;;
+    --script=*)   SCRIPT="${ARG#*=}"; shift; continue ;;
     --location=*) LOCATION="${ARG#*=}"; shift; continue ;;
     --) shift; break ;;
     *) echo "Unknown flag: $ARG"; exit 2 ;;

--- a/commands/host/devkit-var-get
+++ b/commands/host/devkit-var-get
@@ -19,8 +19,8 @@ LOCATION=""
 # Parse flags
 for ARG in "$@"; do
   case "$ARG" in
-    --name=*) NAME="${ARG#*=}"; shift; continue ;;
-    --format=*) FORMAT="${ARG#*=}"; shift; continue ;;
+    --name=*)     NAME="${ARG#*=}"; shift; continue ;;
+    --format=*)   FORMAT="${ARG#*=}"; shift; continue ;;
     --location=*) LOCATION="${ARG#*=}"; shift; continue ;;
     *) echo "Unknown flag: $ARG"; exit 2 ;;
   esac

--- a/commands/host/devkit-var-get
+++ b/commands/host/devkit-var-get
@@ -31,6 +31,7 @@ done
 [[ -n "$FORMAT" ]] || { echo "--format is required."; exit 2; }
 [[ -n "$LOCATION" ]] || { echo "--location is required."; exit 2; }
 
+# Guards
 if [[ "$FORMAT" != "env" ]]; then
   echo "Unsupported --format '$FORMAT'. Only 'env' is supported for now." >&2
   exit 2

--- a/commands/host/devkit-var-get
+++ b/commands/host/devkit-var-get
@@ -41,7 +41,6 @@ fi
 VALUE="$(ddev exec -s "$LOCATION" bash -lc "printenv $(printf '%q' "$NAME")" 2>/dev/null || true)"
 
 if [[ -z "$VALUE" ]]; then
-  # Non-zero return signals not found while staying quiet on stdout
   exit 1
 fi
 

--- a/commands/host/devkit-var-get
+++ b/commands/host/devkit-var-get
@@ -26,7 +26,7 @@ for ARG in "$@"; do
   esac
 done
 
-# Validate
+# Validate flags
 [[ -n "$NAME" ]] || { echo "--name is required."; exit 2; }
 [[ -n "$FORMAT" ]] || { echo "--format is required."; exit 2; }
 [[ -n "$LOCATION" ]] || { echo "--location is required."; exit 2; }

--- a/commands/host/site-auth
+++ b/commands/host/site-auth
@@ -10,8 +10,5 @@
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail
 
-# Path to the site scripts
-SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
-
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-auth.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-auth.sh" --location=host

--- a/commands/host/site-build
+++ b/commands/host/site-build
@@ -10,8 +10,5 @@
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail
 
-# Path to the site scripts
-SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
-
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-build.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-build.sh" --location=host

--- a/commands/host/site-build-backend
+++ b/commands/host/site-build-backend
@@ -10,8 +10,5 @@
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail
 
-# Path to the site scripts
-SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
-
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-build-backend.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-build-backend.sh" --location=host

--- a/commands/host/site-build-frontend
+++ b/commands/host/site-build-frontend
@@ -10,8 +10,5 @@
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail
 
-# Path to the site scripts
-SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
-
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-build-frontend.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-build-frontend.sh" --location=host

--- a/commands/host/site-install
+++ b/commands/host/site-install
@@ -10,8 +10,5 @@
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail
 
-# Path to the site scripts
-SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
-
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-install.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-install.sh" --location=host

--- a/commands/host/site-mode-development
+++ b/commands/host/site-mode-development
@@ -10,8 +10,5 @@
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail
 
-# Path to the site scripts
-SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
-
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-mode-development.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-mode-development.sh" --location=host

--- a/commands/host/site-mode-production
+++ b/commands/host/site-mode-production
@@ -10,8 +10,5 @@
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail
 
-# Path to the site scripts
-SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
-
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-mode-production.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-mode-production.sh" --location=host

--- a/commands/host/site-scaffold
+++ b/commands/host/site-scaffold
@@ -10,8 +10,5 @@
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail
 
-# Path to the site scripts
-SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
-
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-scaffold.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-scaffold.sh" --location=host

--- a/commands/host/site-sync
+++ b/commands/host/site-sync
@@ -10,8 +10,5 @@
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail
 
-# Path to the site scripts
-SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
-
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-sync.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-sync.sh" --location=host

--- a/commands/host/site-sync-backend
+++ b/commands/host/site-sync-backend
@@ -10,8 +10,5 @@
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail
 
-# Path to the site scripts
-SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
-
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-sync-backend.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-sync-backend.sh" --location=host

--- a/commands/host/site-sync-frontend
+++ b/commands/host/site-sync-frontend
@@ -10,8 +10,5 @@
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail
 
-# Path to the site scripts
-SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
-
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-sync-frontend.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-sync-frontend.sh" --location=host

--- a/commands/host/site-test
+++ b/commands/host/site-test
@@ -10,8 +10,5 @@
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail
 
-# Path to the site scripts
-SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
-
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-test.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-test.sh" --location=host

--- a/commands/host/site-test-backend
+++ b/commands/host/site-test-backend
@@ -10,8 +10,5 @@
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail
 
-# Path to the site scripts
-SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
-
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-test-backend.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-test-backend.sh" --location=host

--- a/commands/host/site-test-frontend
+++ b/commands/host/site-test-frontend
@@ -10,8 +10,5 @@
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail
 
-# Path to the site scripts
-SITE_SCRIPTS=".ddev/site-devkit/site/scripts"
-
 # Run the script
-ddev devkit-script-run --script="$SITE_SCRIPTS/site-test-frontend.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-test-frontend.sh" --location=host

--- a/install.yaml
+++ b/install.yaml
@@ -2,6 +2,7 @@ name: site-devkit
 
 project_files:
   - commands/host/devkit-db-import
+  - commands/host/devkit-file-copy
   - commands/host/devkit-minio-create-bucket
   - commands/host/devkit-script-run
   - commands/host/devkit-var-get


### PR DESCRIPTION
## The Issue

- Fixes #5

New devkit command for copying files.

## How This PR Solves The Issue

1. Created a new `devkit-file-copy` command.
2. Updated the README.
3. Updated `install.yaml` to copy the file on install/update.
4. Improvements to messaging for all `devkit-*` commands.
5. Improvements to coding style for all `devkit-*` commands, to make things easier to understand and maintain.
6. Updated the `--dir` shorthand flag to `--directory` for `ddev devkit-db-import`, but the command still accepts `--dir`.

## Release/Deployment Notes

1. Introduced a new `devkit-file-copy` command.
2. Made various non-breaking changes to all `devkit-*` commands.