### PR TITLE
[15] devkit-script-run should be more informative

### DIFF
--- a/commands/host/devkit-script-run
+++ b/commands/host/devkit-script-run
@@ -69,7 +69,7 @@ timestamp() {
 # Commands
 echo "[$(timestamp)] Starting script '$SCRIPT' in '$LOCATION'..."
 
-if [[ "$LOCATION" == host ]]; then
+if [[ "$LOCATION" == "host" ]]; then
   bash "$SCRIPT_PATH" "$@"
 else
   ddev exec -s "$LOCATION" bash "$SCRIPT_PATH" "$@"


### PR DESCRIPTION
## The Issue

- Fixes #15

devkit-script-run should be more informative.

## How This PR Solves The Issue

1. Added starting and completed messages before and after a script is run, with a timestamp.
2. Fixed an issue with the completed echo never running.
3. Coding standards.

## Release/Deployment Notes

1. `devkit-script-run` is now more informative, including starting and completed messages, with timestamps.
