### PR TITLE
[11] devkit-db-import file ordering

### DIFF
--- a/commands/host/devkit-db-import
+++ b/commands/host/devkit-db-import
@@ -53,6 +53,10 @@ if (( ${#FILES[@]} == 0 )); then
   exit 1
 fi
 
+# Newest first by modification time
+IFS=$'\n' FILES=($(ls -1t "${FILES[@]}"))
+unset IFS
+
 # Prompts
 echo "Choose a dump file to import from '$DIRECTORY_PATH':"
 for i in "${!FILES[@]}"; do


### PR DESCRIPTION
## The Issue

- Fixes #11

devkit-db-import file ordering.

## How This PR Solves The Issue

1. Ordered files by newest first (modification time).

## Release/Deployment Notes

1. `devkit-db-import` now lists files with the newest first in the list, not last.
