### PR TITLE
[45] Example site scripts should include a comment for reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,16 @@ If your project doesn't need frontend or backend scripts, just leave them unused
 ### How to modify
 1. Open the matching script.
 2. Remove the `#ddev-generated` line (this prevents the script being replaced on update).
-3. Keep the shebang and safety flags:
+3. Remove the `## Script provided by https://github.com/colinstillwell/ddev-site-devkit.` line.
+4. Keep the shebang and safety flags:
    ```bash
    #!/usr/bin/env bash
 
    # Exit on error; treat unset variables as errors; fail pipelines if any command fails
    set -euo pipefail
    ```
-4. Replace the placeholder content with your project's logic.
-5. Use the `ddev devkit-*` commands provided by this add-on where useful.
+5. Replace the placeholder content with your project's logic.
+6. Use the `ddev devkit-*` commands provided by this add-on where useful.
 
 ### Update behaviour
 

--- a/site-devkit/site/scripts/site-auth.sh
+++ b/site-devkit/site/scripts/site-auth.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 #ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/site-devkit/site/scripts/site-build-backend.sh
+++ b/site-devkit/site/scripts/site-build-backend.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 #ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/site-devkit/site/scripts/site-build-frontend.sh
+++ b/site-devkit/site/scripts/site-build-frontend.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 #ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/site-devkit/site/scripts/site-build.sh
+++ b/site-devkit/site/scripts/site-build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 #ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/site-devkit/site/scripts/site-install.sh
+++ b/site-devkit/site/scripts/site-install.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 #ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/site-devkit/site/scripts/site-mode-development.sh
+++ b/site-devkit/site/scripts/site-mode-development.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 #ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/site-devkit/site/scripts/site-mode-production.sh
+++ b/site-devkit/site/scripts/site-mode-production.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 #ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/site-devkit/site/scripts/site-scaffold.sh
+++ b/site-devkit/site/scripts/site-scaffold.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 #ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/site-devkit/site/scripts/site-sync-backend.sh
+++ b/site-devkit/site/scripts/site-sync-backend.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 #ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/site-devkit/site/scripts/site-sync-frontend.sh
+++ b/site-devkit/site/scripts/site-sync-frontend.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 #ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/site-devkit/site/scripts/site-sync.sh
+++ b/site-devkit/site/scripts/site-sync.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 #ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/site-devkit/site/scripts/site-test-backend.sh
+++ b/site-devkit/site/scripts/site-test-backend.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 #ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/site-devkit/site/scripts/site-test-frontend.sh
+++ b/site-devkit/site/scripts/site-test-frontend.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 #ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/site-devkit/site/scripts/site-test.sh
+++ b/site-devkit/site/scripts/site-test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 #ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail


### PR DESCRIPTION
## The Issue

- Fixes #45

Example site scripts should include a comment for reference.

## How This PR Solves The Issue

1. Added comments in the top of each site script.
2. Updated the README.

## Release/Deployment Notes

Nothing notable to shout about.
