### PR TITLE
[49] Rename devkit-var-get to devkit-config-get

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ There are two types of commands provided by this add-on:
 | `devkit-file-copy`           | Copy a file from source to destination within the project, skipping if it already exists |
 | `devkit-minio-create-bucket` | Create a MinIO bucket if it does not exist, and set its policy                           |
 | `devkit-script-run`          | Run a script on the host or in a specified service                                       |
-| `devkit-var-get`             | Get the value of a variable from the specified format and location                       |
+| `devkit-config-get`          | Get a config value by name from a given format and location                              |
 
 ### `ddev site-*` commands
 

--- a/commands/host/devkit-config-get
+++ b/commands/host/devkit-config-get
@@ -2,11 +2,11 @@
 
 #ddev-generated
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
-## Description: Get the value of a variable from the specified format and location.
-## Usage: devkit-var-get [flags]
-## Example: "ddev devkit-var-get --name=EXAMPLE --format=env --location=web"
+## Description: Get a config value by name from a given format and location.
+## Usage: devkit-config-get [flags]
+## Example: "ddev devkit-config-get --name=EXAMPLE --format=env --location=web"
 ## Flags: [{"Name":"name","Usage":"The name of the variable to get the value for","Type":"string"},{"Name":"format","Usage":"How to interpret the location","Type":"string"},{"Name":"location","Usage":"Where to read from","Type":"string"}]
-## Aliases: devkit:var:get,devkit-get-var,devkit:get:var
+## Aliases: devkit:config:get,devkit-get-config,devkit:get:config
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails
 set -euo pipefail

--- a/install.yaml
+++ b/install.yaml
@@ -1,11 +1,11 @@
 name: site-devkit
 
 project_files:
+  - commands/host/devkit-config-get
   - commands/host/devkit-db-import
   - commands/host/devkit-file-copy
   - commands/host/devkit-minio-create-bucket
   - commands/host/devkit-script-run
-  - commands/host/devkit-var-get
   - commands/host/site-auth
   - commands/host/site-build
   - commands/host/site-build-backend


### PR DESCRIPTION
## The Issue

- Fixes #49

Rename devkit-var-get to devkit-config-get.

## How This PR Solves The Issue

1. Renamed `devkit-var-get` to `devkit-config-get`.
2. Updated the README.
3. Updated `install.yaml`.

## Release/Deployment Notes

1. `devkit-var-get` has been deprecated, in favour of `devkit-config-get`. All flags remain untouched.
