### PR TITLE
[10] New devkit command for comparing env file variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ There are two types of commands provided by this add-on:
 
 | Command                      | Description                                                                              |
 | ---------------------------- | ---------------------------------------------------------------------------------------- |
+| `devkit-config-diff`         | Compare config and report keys present in reference but missing in target                |
+| `devkit-config-get`          | Get a config value by name from a given format and location                              |
 | `devkit-db-import`           | Interactively import an SQL dump into the project database                               |
 | `devkit-file-copy`           | Copy a file from source to destination within the project, skipping if it already exists |
 | `devkit-minio-create-bucket` | Create a MinIO bucket if it does not exist, and set its policy                           |
 | `devkit-script-run`          | Run a script on the host or in a specified service                                       |
-| `devkit-config-get`          | Get a config value by name from a given format and location                              |
 
 ### `ddev site-*` commands
 

--- a/commands/host/devkit-config-diff
+++ b/commands/host/devkit-config-diff
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/colinstillwell/ddev-site-devkit
+## Description: Compare config and report keys present in reference but missing in target.
+## Usage: devkit-config-diff [flags]
+## Example: "ddev devkit-config-diff --format=env --reference=.env.example --target=.env"
+## Flags: [{"Name":"format","Usage":"How to interpret the config","Type":"string"},{"Name":"reference","Usage":"Path to the reference config, relative to the project root","Type":"string"},{"Name":"target","Usage":"Path to the target config, relative to the project root","Type":"string"}]
+## Aliases: devkit:config:diff,devkit-diff-config,devkit:diff:config
+
+# Exit on error; treat unset variables as errors; fail pipelines if any command fails
+set -euo pipefail
+
+# Defaults
+FORMAT=""
+REFERENCE=""
+TARGET=""
+
+# Parse flags
+for ARG in "$@"; do
+  case "$ARG" in
+    --format=*)   FORMAT="${ARG#*=}"; shift; continue ;;
+    --reference=*) REFERENCE="${ARG#*=}"; shift; continue ;;
+    --target=*) TARGET="${ARG#*=}"; shift; continue ;;
+    *) echo "Unknown flag: $ARG"; exit 2 ;;
+  esac
+done
+
+# Validate flags
+[[ -n "$FORMAT" ]] || { echo "--format is required."; exit 2; }
+[[ -n "$REFERENCE" ]] || { echo "--reference is required."; exit 2; }
+[[ -n "$TARGET" ]] || { echo "--target is required."; exit 2; }
+
+# Guards
+if [[ "$FORMAT" != "env" ]]; then
+  echo "Unsupported --format '$FORMAT'. Only 'env' is supported for now." >&2
+  exit 2
+fi
+
+REFERENCE_PATH="$DDEV_APPROOT/$REFERENCE"
+TARGET_PATH="$DDEV_APPROOT/$TARGET"
+
+if [[ -d "$REFERENCE_PATH" ]]; then
+  echo "'$REFERENCE_PATH' is a directory. Cannot compare with '$TARGET_PATH'."
+  exit 1
+fi
+
+if [[ -d "$TARGET_PATH" ]]; then
+  echo "'$TARGET_PATH' is a directory. Cannot compare with '$REFERENCE_PATH'."
+  exit 1
+fi
+
+if [[ ! -f "$REFERENCE_PATH" ]]; then
+  echo "'$REFERENCE_PATH' not found. Cannot compare with '$TARGET_PATH'."
+  exit 1
+fi
+
+if [[ ! -f "$TARGET_PATH" ]]; then
+  echo "'$TARGET_PATH' not found. Cannot compare with '$REFERENCE_PATH'."
+  exit 1
+fi
+
+# Commands
+echo "Comparing '$REFERENCE' to '$TARGET'..."
+
+extract_env_keys() {
+  awk -F'=' '
+    /^[[:space:]]*#/ { next }           # comments
+    /^[[:space:]]*$/ { next }           # empty
+    {
+      line=$0
+      sub(/\r$/,"", line)               # strip Windows CR if present
+      sub(/^[[:space:]]*export[[:space:]]+/, "", line)
+      split(line, parts, "=")
+      key=parts[1]
+      sub(/^[[:space:]]+/, "", key)
+      sub(/[[:space:]]+$/, "", key)
+      if (key ~ /^[A-Za-z_][A-Za-z0-9_]*$/) print key
+    }
+  ' "$1" | sort -u
+}
+
+MISSING=$(
+  comm -23 <(extract_env_keys "$REFERENCE_PATH") <(extract_env_keys "$TARGET_PATH") || true
+)
+
+if [[ -z "$MISSING" ]]; then
+  echo "All keys in '$REFERENCE' are present in '$TARGET'."
+  exit 0
+fi
+
+echo "The following keys are in '$REFERENCE' but are missing from '$TARGET':"
+printf '  - %s\n' $MISSING
+exit 1

--- a/install.yaml
+++ b/install.yaml
@@ -1,6 +1,7 @@
 name: site-devkit
 
 project_files:
+  - commands/host/devkit-config-diff
   - commands/host/devkit-config-get
   - commands/host/devkit-db-import
   - commands/host/devkit-file-copy


### PR DESCRIPTION
## The Issue

- Fixes #10

New devkit command for comparing env file variables

## How This PR Solves The Issue

1. Created a new `devkit-config-diff` command.
2. Updated the README.
3. Updated the `install.yaml`.

## Release/Deployment Notes

1. Introduced a new `devkit-config-diff` command for comparing config and report keys present in reference but missing in target.