### PR TITLE
[52] Create site-install frontend and backend wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ There are two types of commands provided by this add-on:
 | `site-build-frontend`   | Frontend build tasks           | NPM install                                                             |
 | `site-install`          | Installation tasks             | New project installs the application; existing project builds and syncs |
 | `site-install-backend`  | Backend installation tasks     | New project installs the application; existing project builds and syncs |
+| `site-install-frontend` | Frontend installation tasks    | New project installs the application; existing project builds and syncs |
 | `site-mode-development` | Enable development mode        | Disable caches, enable verbose logging                                  |
 | `site-mode-production`  | Enable production mode         | Enable caches, aggregate CSS and JS                                     |
 | `site-scaffold`         | Scaffolding tasks              | Copy required files, set permissions                                    |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ There are two types of commands provided by this add-on:
 | `site-build`            | Build tasks                    | Wraps tasks for the backend and frontend                                |
 | `site-build-backend`    | Backend build tasks            | Composer install                                                        |
 | `site-build-frontend`   | Frontend build tasks           | NPM install                                                             |
-| `site-install`          | Installation tasks             | New project installs the application; existing project builds and syncs |
+| `site-install`          | Installation tasks             | Wraps tasks for the backend and frontend                                |
 | `site-install-backend`  | Backend installation tasks     | New project installs the application; existing project builds and syncs |
 | `site-install-frontend` | Frontend installation tasks    | New project installs the application; existing project builds and syncs |
 | `site-mode-development` | Enable development mode        | Disable caches, enable verbose logging                                  |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ There are two types of commands provided by this add-on:
 | `site-build-backend`    | Backend build tasks            | Composer install                                                        |
 | `site-build-frontend`   | Frontend build tasks           | NPM install                                                             |
 | `site-install`          | Installation tasks             | New project installs the application; existing project builds and syncs |
+| `site-install-backend`  | Backend installation tasks     | New project installs the application; existing project builds and syncs |
 | `site-mode-development` | Enable development mode        | Disable caches, enable verbose logging                                  |
 | `site-mode-production`  | Enable production mode         | Enable caches, aggregate CSS and JS                                     |
 | `site-scaffold`         | Scaffolding tasks              | Copy required files, set permissions                                    |

--- a/commands/host/site-install-backend
+++ b/commands/host/site-install-backend
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/colinstillwell/ddev-site-devkit
+## Description: Backend installation tasks.
+## Usage: site-install-backend
+## Example: "ddev site-install-backend"
+## Aliases: site:install:backend,site-install-be,site:install:be,site-backend-install,site:backend:install,site-be-install,site:be:install
+
+# Exit on error; treat unset variables as errors; fail pipelines if any command fails
+set -euo pipefail
+
+# Run the script
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-install-backend.sh" --location=host

--- a/commands/host/site-install-frontend
+++ b/commands/host/site-install-frontend
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/colinstillwell/ddev-site-devkit
+## Description: Frontend installation tasks.
+## Usage: site-install-frontend
+## Example: "ddev site-install-frontend"
+## Aliases: site:install:frontend,site-install-fe,site:install:fe,site-frontend-install,site:frontend:install,site-fe-install,site:fe:install
+
+# Exit on error; treat unset variables as errors; fail pipelines if any command fails
+set -euo pipefail
+
+# Run the script
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-install-frontend.sh" --location=host

--- a/install.yaml
+++ b/install.yaml
@@ -12,6 +12,7 @@ project_files:
   - commands/host/site-build-backend
   - commands/host/site-build-frontend
   - commands/host/site-install
+  - commands/host/site-install-backend
   - commands/host/site-mode-development
   - commands/host/site-mode-production
   - commands/host/site-scaffold
@@ -26,6 +27,7 @@ project_files:
   - site-devkit/site/scripts/site-build-backend.sh
   - site-devkit/site/scripts/site-build-frontend.sh
   - site-devkit/site/scripts/site-install.sh
+  - site-devkit/site/scripts/site-install-backend.sh
   - site-devkit/site/scripts/site-mode-development.sh
   - site-devkit/site/scripts/site-mode-production.sh
   - site-devkit/site/scripts/site-scaffold.sh

--- a/install.yaml
+++ b/install.yaml
@@ -13,6 +13,7 @@ project_files:
   - commands/host/site-build-frontend
   - commands/host/site-install
   - commands/host/site-install-backend
+  - commands/host/site-install-frontend
   - commands/host/site-mode-development
   - commands/host/site-mode-production
   - commands/host/site-scaffold
@@ -28,6 +29,7 @@ project_files:
   - site-devkit/site/scripts/site-build-frontend.sh
   - site-devkit/site/scripts/site-install.sh
   - site-devkit/site/scripts/site-install-backend.sh
+  - site-devkit/site/scripts/site-install-frontend.sh
   - site-devkit/site/scripts/site-mode-development.sh
   - site-devkit/site/scripts/site-mode-production.sh
   - site-devkit/site/scripts/site-scaffold.sh

--- a/site-devkit/site/scripts/site-install-backend.sh
+++ b/site-devkit/site/scripts/site-install-backend.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
+
+# Exit on error; treat unset variables as errors; fail pipelines if any command fails
+set -euo pipefail
+
+cat <<'EXAMPLE'
+This script has not been customised for your project yet.
+
+For guidance on how to adapt it, see "Customising the generated scripts" in the add-on documentation:
+https://github.com/colinstillwell/ddev-site-devkit#customising-the-generated-scripts
+EXAMPLE

--- a/site-devkit/site/scripts/site-install-frontend.sh
+++ b/site-devkit/site/scripts/site-install-frontend.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Script provided by https://github.com/colinstillwell/ddev-site-devkit.
+
+# Exit on error; treat unset variables as errors; fail pipelines if any command fails
+set -euo pipefail
+
+cat <<'EXAMPLE'
+This script has not been customised for your project yet.
+
+For guidance on how to adapt it, see "Customising the generated scripts" in the add-on documentation:
+https://github.com/colinstillwell/ddev-site-devkit#customising-the-generated-scripts
+EXAMPLE

--- a/site-devkit/site/scripts/site-install.sh
+++ b/site-devkit/site/scripts/site-install.sh
@@ -13,18 +13,10 @@ For guidance on how to adapt it, see "Customising the generated scripts" in the 
 https://github.com/colinstillwell/ddev-site-devkit#customising-the-generated-scripts
 EXAMPLE
 
-# Run backend build tasks
-# echo "Running backend build tasks..."
-# ddev site-build-backend
+# Run backend installation tasks
+# echo "Running backend installation tasks..."
+# ddev site-install-backend
 
-# Run backend synchronisation tasks
-# echo "Running backend synchronisation tasks..."
-# ddev site-sync-backend
-
-# Run frontend build tasks
-# echo "Running frontend build tasks..."
-# ddev site-build-frontend
-
-# Run frontend synchronisation tasks
-# echo "Running frontend synchronisation tasks..."
-# ddev site-sync-frontend
+# Run frontend installation tasks
+# echo "Running frontend installation tasks..."
+# ddev site-install-frontend


### PR DESCRIPTION
## The Issue

- Fixes #52

Create site-install frontend and backend wrappers.

## How This PR Solves The Issue

1. Created a `site-install-backend` command.
2. Created a `site-install-frontend` command.
3. Created supporting scripts for both commands.
4. Updated the `install.yaml` to include both commands and their supporting scripts.
5. Updated the `site-install` script to use the new `site-install-backend` and `site-install-frontend` commands.
6. Updated the README for `site-install`.

## Release/Deployment Notes

1. Introduced a `site-install-backend` command.
2. Introduced a `site-install-frontend` command.
