### PR TITLE
[52] Add missing examples for site-install-backend and site-install-frontend

### DIFF
--- a/site-devkit/site/scripts/site-install-backend.sh
+++ b/site-devkit/site/scripts/site-install-backend.sh
@@ -12,3 +12,11 @@ This script has not been customised for your project yet.
 For guidance on how to adapt it, see "Customising the generated scripts" in the add-on documentation:
 https://github.com/colinstillwell/ddev-site-devkit#customising-the-generated-scripts
 EXAMPLE
+
+# Run backend build tasks
+# echo "Running backend build tasks..."
+# ddev site-build-backend
+
+# Run backend synchronisation tasks
+# echo "Running backend synchronisation tasks..."
+# ddev site-sync-backend

--- a/site-devkit/site/scripts/site-install-frontend.sh
+++ b/site-devkit/site/scripts/site-install-frontend.sh
@@ -12,3 +12,11 @@ This script has not been customised for your project yet.
 For guidance on how to adapt it, see "Customising the generated scripts" in the add-on documentation:
 https://github.com/colinstillwell/ddev-site-devkit#customising-the-generated-scripts
 EXAMPLE
+
+# Run frontend build tasks
+# echo "Running frontend build tasks..."
+# ddev site-build-frontend
+
+# Run frontend synchronisation tasks
+# echo "Running frontend synchronisation tasks..."
+# ddev site-sync-frontend


### PR DESCRIPTION
## The Issue

Add missing examples for site-install-backend and site-install-frontend.

## How This PR Solves The Issue

1. Added missing examples.

## Release/Deployment Notes

Nothing notable.
