### PR TITLE
[55] devkit-config-get should be informative on error

### DIFF
--- a/commands/host/devkit-config-get
+++ b/commands/host/devkit-config-get
@@ -41,6 +41,7 @@ fi
 VALUE="$(ddev exec -s "$LOCATION" bash -lc "printenv $(printf '%q' "$NAME")" 2>/dev/null || true)"
 
 if [[ -z "$VALUE" ]]; then
+  echo "No '$FORMAT' value found for '$NAME' in '$LOCATION'."
   exit 1
 fi
 


### PR DESCRIPTION
## The Issue

- Fixes #55

devkit-config-get should be informative on error.

## How This PR Solves The Issue

1. Added an echo before the `exit 1`.

## Release/Deployment Notes

Nothing notable.
