### PR TITLE
[9] New devkit command for handing errors and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ There are two types of commands provided by this add-on:
 | `devkit-config-get`          | Get a config value by name from a given format and location                              |
 | `devkit-db-import`           | Interactively import an SQL dump into the project database                               |
 | `devkit-file-copy`           | Copy a file from source to destination within the project, skipping if it already exists |
+| `devkit-log`                 | Print a formatted log message                                                            |
 | `devkit-minio-create-bucket` | Create a MinIO bucket if it does not exist, and set its policy                           |
 | `devkit-script-run`          | Run a script on the host or in a specified service                                       |
 

--- a/commands/host/devkit-config-diff
+++ b/commands/host/devkit-config-diff
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Compare config and report keys present in reference but missing in target.
 ## Usage: devkit-config-diff [flags]
-## Example: "ddev devkit-config-diff --format=env --reference=.env.example --target=.env"
+## Example: ddev devkit-config-diff --format=env --reference=.env.example --target=.env
 ## Flags: [{"Name":"format","Usage":"How to interpret the config","Type":"string"},{"Name":"reference","Usage":"Path to the reference config, relative to the project root","Type":"string"},{"Name":"target","Usage":"Path to the target config, relative to the project root","Type":"string"}]
 ## Aliases: devkit:config:diff,devkit-diff-config,devkit:diff:config
 

--- a/commands/host/devkit-config-diff
+++ b/commands/host/devkit-config-diff
@@ -65,11 +65,11 @@ ddev devkit-log --message="Comparing '$REFERENCE' to '$TARGET'..."
 
 extract_env_keys() {
   awk -F'=' '
-    /^[[:space:]]*#/ { next }           # comments
-    /^[[:space:]]*$/ { next }           # empty
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*$/ { next }
     {
       line=$0
-      sub(/\r$/,"", line)               # strip Windows CR if present
+      sub(/\r$/,"", line)
       sub(/^[[:space:]]*export[[:space:]]+/, "", line)
       split(line, parts, "=")
       key=parts[1]

--- a/commands/host/devkit-config-diff
+++ b/commands/host/devkit-config-diff
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Compare config and report keys present in reference but missing in target.
 ## Usage: devkit-config-diff [flags]
-## Example: ddev devkit-config-diff --format=env --reference=.env.example --target=.env
+## Example: ddev devkit-config-diff --format="env" --reference=".env.example" --target=".env"
 ## Flags: [{"Name":"format","Usage":"How to interpret the config","Type":"string"},{"Name":"reference","Usage":"Path to the reference config, relative to the project root","Type":"string"},{"Name":"target","Usage":"Path to the target config, relative to the project root","Type":"string"}]
 ## Aliases: devkit:config:diff,devkit-diff-config,devkit:diff:config
 

--- a/commands/host/devkit-config-diff
+++ b/commands/host/devkit-config-diff
@@ -22,18 +22,18 @@ for ARG in "$@"; do
     --format=*)    FORMAT="${ARG#*=}"; shift; continue ;;
     --reference=*) REFERENCE="${ARG#*=}"; shift; continue ;;
     --target=*)    TARGET="${ARG#*=}"; shift; continue ;;
-    *) echo "Unknown flag: $ARG" >&2; exit 2 ;;
+    *) ddev devkit-log --message="Unknown flag: $ARG" --type="error"; exit 2 ;;
   esac
 done
 
 # Validate flags
-[[ -n "$FORMAT" ]]    || { echo "--format is required." >&2; exit 2; }
-[[ -n "$REFERENCE" ]] || { echo "--reference is required." >&2; exit 2; }
-[[ -n "$TARGET" ]]    || { echo "--target is required." >&2; exit 2; }
+[[ -n "$FORMAT" ]]    || { ddev devkit-log --message="--format is required." --type="error"; exit 2; }
+[[ -n "$REFERENCE" ]] || { ddev devkit-log --message="--reference is required." --type="error"; exit 2; }
+[[ -n "$TARGET" ]]    || { ddev devkit-log --message="--target is required." --type="error"; exit 2; }
 
 # Guards
 if [[ "$FORMAT" != "env" ]]; then
-  echo "Unsupported --format '$FORMAT'. Only 'env' is supported for now." >&2
+  ddev devkit-log --message="Unsupported --format '$FORMAT'. Only 'env' is supported for now." --type="error"
   exit 2
 fi
 
@@ -41,27 +41,27 @@ REFERENCE_PATH="$DDEV_APPROOT/$REFERENCE"
 TARGET_PATH="$DDEV_APPROOT/$TARGET"
 
 if [[ -d "$REFERENCE_PATH" ]]; then
-  echo "'$REFERENCE_PATH' is a directory. Cannot compare with '$TARGET_PATH'." >&2
+  ddev devkit-log --message="'$REFERENCE_PATH' is a directory. Cannot compare with '$TARGET_PATH'." --type="error"
   exit 1
 fi
 
 if [[ -d "$TARGET_PATH" ]]; then
-  echo "'$TARGET_PATH' is a directory. Cannot compare with '$REFERENCE_PATH'." >&2
+  ddev devkit-log --message="'$TARGET_PATH' is a directory. Cannot compare with '$REFERENCE_PATH'." --type="error"
   exit 1
 fi
 
 if [[ ! -f "$REFERENCE_PATH" ]]; then
-  echo "'$REFERENCE_PATH' not found. Cannot compare with '$TARGET_PATH'." >&2
+  ddev devkit-log --message="'$REFERENCE_PATH' not found. Cannot compare with '$TARGET_PATH'." --type="error"
   exit 1
 fi
 
 if [[ ! -f "$TARGET_PATH" ]]; then
-  echo "'$TARGET_PATH' not found. Cannot compare with '$REFERENCE_PATH'." >&2
+  ddev devkit-log --message="'$TARGET_PATH' not found. Cannot compare with '$REFERENCE_PATH'." --type="error"
   exit 1
 fi
 
 # Commands
-echo "Comparing '$REFERENCE' to '$TARGET'..." >&2
+ddev devkit-log --message="Comparing '$REFERENCE' to '$TARGET'..."
 
 extract_env_keys() {
   awk -F'=' '
@@ -85,10 +85,10 @@ MISSING=$(
 )
 
 if [[ -z "$MISSING" ]]; then
-  echo "All keys in '$REFERENCE' are present in '$TARGET'." >&2
+  ddev devkit-log --message="All keys in '$REFERENCE' are present in '$TARGET'." --type="success"
   exit 0
 fi
 
-echo "The following keys are in '$REFERENCE' but are missing from '$TARGET':" >&2
+ddev devkit-log --message="The following keys are in '$REFERENCE' but are missing from '$TARGET':" --type="error"
 printf '%s\n' "$MISSING"
 exit 1

--- a/commands/host/devkit-config-get
+++ b/commands/host/devkit-config-get
@@ -22,18 +22,18 @@ for ARG in "$@"; do
     --name=*)     NAME="${ARG#*=}"; shift; continue ;;
     --format=*)   FORMAT="${ARG#*=}"; shift; continue ;;
     --location=*) LOCATION="${ARG#*=}"; shift; continue ;;
-    *) echo "Unknown flag: $ARG" >&2; exit 2 ;;
+    *) ddev devkit-log --message="Unknown flag: $ARG" --type="error"; exit 2 ;;
   esac
 done
 
 # Validate flags
-[[ -n "$NAME" ]]     || { echo "--name is required." >&2; exit 2; }
-[[ -n "$FORMAT" ]]   || { echo "--format is required." >&2; exit 2; }
-[[ -n "$LOCATION" ]] || { echo "--location is required." >&2; exit 2; }
+[[ -n "$NAME" ]]     || { ddev devkit-log --message="--name is required." --type="error"; exit 2; }
+[[ -n "$FORMAT" ]]   || { ddev devkit-log --message="--format is required." --type="error"; exit 2; }
+[[ -n "$LOCATION" ]] || { ddev devkit-log --message="--location is required." --type="error"; exit 2; }
 
 # Guards
 if [[ "$FORMAT" != "env" ]]; then
-  echo "Unsupported --format '$FORMAT'. Only 'env' is supported for now." >&2
+  ddev devkit-log --message="Unsupported --format '$FORMAT'. Only 'env' is supported for now." --type="error"
   exit 2
 fi
 
@@ -41,7 +41,7 @@ fi
 VALUE="$(ddev exec -s "$LOCATION" bash -lc "printenv $(printf '%q' "$NAME")" 2>/dev/null || true)"
 
 if [[ -z "$VALUE" ]]; then
-  echo "No '$FORMAT' value found for '$NAME' in '$LOCATION'." >&2
+  ddev devkit-log --message="No '$FORMAT' value found for '$NAME' in '$LOCATION'." --type="error"
   exit 1
 fi
 

--- a/commands/host/devkit-config-get
+++ b/commands/host/devkit-config-get
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Get a config value by name from a given format and location.
 ## Usage: devkit-config-get [flags]
-## Example: "ddev devkit-config-get --name=EXAMPLE --format=env --location=web"
+## Example: ddev devkit-config-get --name=EXAMPLE --format=env --location=web
 ## Flags: [{"Name":"name","Usage":"The name of the variable to get the value for","Type":"string"},{"Name":"format","Usage":"How to interpret the location","Type":"string"},{"Name":"location","Usage":"Where to read from","Type":"string"}]
 ## Aliases: devkit:config:get,devkit-get-config,devkit:get:config
 

--- a/commands/host/devkit-config-get
+++ b/commands/host/devkit-config-get
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Get a config value by name from a given format and location.
 ## Usage: devkit-config-get [flags]
-## Example: ddev devkit-config-get --name=EXAMPLE --format=env --location=web
+## Example: ddev devkit-config-get --name="EXAMPLE" --format="env" --location="web"
 ## Flags: [{"Name":"name","Usage":"The name of the variable to get the value for","Type":"string"},{"Name":"format","Usage":"How to interpret the location","Type":"string"},{"Name":"location","Usage":"Where to read from","Type":"string"}]
 ## Aliases: devkit:config:get,devkit-get-config,devkit:get:config
 

--- a/commands/host/devkit-db-import
+++ b/commands/host/devkit-db-import
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Interactively import an SQL dump into the project database.
 ## Usage: devkit-db-import [flags]
-## Example: ddev devkit-db-import --directory=backups
+## Example: ddev devkit-db-import --directory="backups"
 ## Flags: [{"Name":"directory","Usage":"Path to the directory to look for dump files, relative to the project root","Type":"string"}]
 ## Aliases: devkit:db:import,devkit-import-db,devkit:import:db,devkit-database-import,devkit:database:import,devkit-import-database,devkit:import:database
 

--- a/commands/host/devkit-db-import
+++ b/commands/host/devkit-db-import
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Interactively import an SQL dump into the project database.
 ## Usage: devkit-db-import [flags]
-## Example: "ddev devkit-db-import --directory=backups"
+## Example: ddev devkit-db-import --directory=backups
 ## Flags: [{"Name":"directory","Usage":"Path to the directory to look for dump files, relative to the project root","Type":"string"}]
 ## Aliases: devkit:db:import,devkit-import-db,devkit:import:db,devkit-database-import,devkit:database:import,devkit-import-database,devkit:import:database
 

--- a/commands/host/devkit-db-import
+++ b/commands/host/devkit-db-import
@@ -19,7 +19,7 @@ for ARG in "$@"; do
   case "$ARG" in
     --directory=*) DIRECTORY="${ARG#*=}"; shift; continue ;;
     --dir=*)       DIRECTORY="${ARG#*=}"; shift; continue ;;
-    *) echo "Unknown flag: $ARG" >&2; exit 2 ;;
+    *) ddev devkit-log --message="Unknown flag: $ARG" --type="error"; exit 2 ;;
   esac
 done
 
@@ -27,7 +27,7 @@ done
 DIRECTORY_PATH="$DDEV_APPROOT/$DIRECTORY"
 
 if [[ ! -d "$DIRECTORY_PATH" ]]; then
-  echo "Directory not found. Cannot locate dump files in '$DIRECTORY_PATH'." >&2
+  ddev devkit-log --message="Directory not found. Cannot locate dump files in '$DIRECTORY_PATH'." --type="error"
   exit 1
 fi
 
@@ -49,7 +49,7 @@ FILES=(
 shopt -u nullglob
 
 if (( ${#FILES[@]} == 0 )); then
-  echo "Cannot locate dump files in '$DIRECTORY_PATH'." >&2
+  ddev devkit-log --message="Cannot locate dump files in '$DIRECTORY_PATH'." --type="error"
   exit 1
 fi
 
@@ -58,7 +58,7 @@ IFS=$'\n' FILES=($(ls -1t "${FILES[@]}"))
 unset IFS
 
 # Prompts
-echo "Choose a dump file to import from '$DIRECTORY_PATH':" >&2
+ddev devkit-log --message="Choose a dump file to import from '$DIRECTORY_PATH':"
 for i in "${!FILES[@]}"; do
   printf "%2d) %s\n" $((i+1)) "$(basename -- "${FILES[$i]}")" >&2
 done
@@ -70,9 +70,9 @@ while true; do
     CHOICE="${FILES[$((n-1))]}"
     break
   fi
-  echo "Invalid selection. Please try again." >&2
+  ddev devkit-log --message="Invalid selection. Please try again." --type="error"
 done
 
 # Commands
-echo "Importing dump file '$(basename -- "$CHOICE")'..." >&2
+ddev devkit-log --message="Importing dump file '$(basename -- "$CHOICE")'..."
 exec ddev import-db -f "$CHOICE"

--- a/commands/host/devkit-db-import
+++ b/commands/host/devkit-db-import
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Interactively import an SQL dump into the project database.
 ## Usage: devkit-db-import [flags]
-## Example: ddev devkit-db-import --directory="backups"
+## Example: ddev devkit-db-import (default directory: "database")\nddev devkit-db-import --directory="backups"
 ## Flags: [{"Name":"directory","Usage":"Path to the directory to look for dump files, relative to the project root","Type":"string"}]
 ## Aliases: devkit:db:import,devkit-import-db,devkit:import:db,devkit-database-import,devkit:database:import,devkit-import-database,devkit:import:database
 

--- a/commands/host/devkit-file-copy
+++ b/commands/host/devkit-file-copy
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Copy a file from source to destination within the project, skipping if it already exists.
 ## Usage: devkit-file-copy [flags]
-## Example: ddev devkit-file-copy --source=.env.example --destination=.env
+## Example: ddev devkit-file-copy --source=".env.example" --destination=".env"
 ## Flags: [{"Name":"source","Usage":"Path to the file to copy, relative to the project root","Type":"string"},{"Name":"destination","Usage":"Path to copy the file to, relative to the project root","Type":"string"}]
 ## Aliases: devkit:file:copy,devkit-copy-file,devkit:copy:file
 

--- a/commands/host/devkit-file-copy
+++ b/commands/host/devkit-file-copy
@@ -22,13 +22,13 @@ for ARG in "$@"; do
     --src=*)         SOURCE="${ARG#*=}"; shift; continue ;;
     --destination=*) DESTINATION="${ARG#*=}"; shift; continue ;;
     --dest=*)        DESTINATION="${ARG#*=}"; shift; continue ;;
-    *) echo "Unknown flag: $ARG" >&2; exit 2 ;;
+    *) ddev devkit-log --message="Unknown flag: $ARG" --type="error"; exit 2 ;;
   esac
 done
 
 # Validate flags
-[[ -n "$SOURCE" ]]      || { echo "--source is required." >&2; exit 2; }
-[[ -n "$DESTINATION" ]] || { echo "--destination is required." >&2; exit 2; }
+[[ -n "$SOURCE" ]]      || { ddev devkit-log --message="--source is required." --type="error"; exit 2; }
+[[ -n "$DESTINATION" ]] || { ddev devkit-log --message="--destination is required." --type="error"; exit 2; }
 
 # Guards
 SOURCE_PATH="$DDEV_APPROOT/$SOURCE"
@@ -36,35 +36,35 @@ DESTINATION_PATH="$DDEV_APPROOT/$DESTINATION"
 DESTINATION_DIR="$(dirname "$DESTINATION_PATH")"
 
 if [[ -d "$SOURCE_PATH" ]]; then
-  echo "'$SOURCE_PATH' is a directory. Refusing to copy to '$DESTINATION_PATH'." >&2
+  ddev devkit-log --message="'$SOURCE_PATH' is a directory. Refusing to copy to '$DESTINATION_PATH'." --type="error"
   exit 1
 fi
 
 if [[ -d "$DESTINATION_PATH" ]]; then
-  echo "'$DESTINATION_PATH' is a directory. Refusing to overwrite a directory with a file." >&2
+  ddev devkit-log --message="'$DESTINATION_PATH' is a directory. Refusing to overwrite a directory with a file." --type="error"
   exit 1
 fi
 
 if [[ ! -d "$DESTINATION_DIR" ]]; then
-  echo "Destination directory '$DESTINATION_DIR' not found. Cannot copy to '$DESTINATION_PATH'." >&2
+  ddev devkit-log --message="Destination directory '$DESTINATION_DIR' not found. Cannot copy to '$DESTINATION_PATH'." --type="error"
   exit 1
 fi
 
 if [[ ! -f "$SOURCE_PATH" ]]; then
-  echo "'$SOURCE_PATH' not found. Cannot copy to '$DESTINATION_PATH'." >&2
+  ddev devkit-log --message="'$SOURCE_PATH' not found. Cannot copy to '$DESTINATION_PATH'." --type="error"
   exit 1
 fi
 
 if [[ -e "$DESTINATION_PATH" ]] && [[ "$SOURCE_PATH" -ef "$DESTINATION_PATH" ]]; then
-  echo "'$SOURCE_PATH' and '$DESTINATION_PATH' refer to the same file. Nothing to do." >&2
+  ddev devkit-log --message="'$SOURCE_PATH' and '$DESTINATION_PATH' refer to the same file. Nothing to do." --type="warning"
   exit 0
 fi
 
 if [[ -f "$DESTINATION_PATH" ]]; then
-  echo "'$DESTINATION_PATH' already exists. Nothing to do." >&2
+  ddev devkit-log --message="'$DESTINATION_PATH' already exists. Nothing to do." --type="success"
   exit 0
 fi
 
 # Commands
-echo "Copying '$SOURCE_PATH' to '$DESTINATION_PATH'..." >&2
+ddev devkit-log --message="Copying '$SOURCE_PATH' to '$DESTINATION_PATH'..."
 cp "$SOURCE_PATH" "$DESTINATION_PATH"

--- a/commands/host/devkit-file-copy
+++ b/commands/host/devkit-file-copy
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Copy a file from source to destination within the project, skipping if it already exists.
 ## Usage: devkit-file-copy [flags]
-## Example: "ddev devkit-file-copy --source=.env.example --destination=.env"
+## Example: ddev devkit-file-copy --source=.env.example --destination=.env
 ## Flags: [{"Name":"source","Usage":"Path to the file to copy, relative to the project root","Type":"string"},{"Name":"destination","Usage":"Path to copy the file to, relative to the project root","Type":"string"}]
 ## Aliases: devkit:file:copy,devkit-copy-file,devkit:copy:file
 

--- a/commands/host/devkit-log
+++ b/commands/host/devkit-log
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/colinstillwell/ddev-site-devkit
+## Description: Print a formatted log message.
+## Usage: devkit-log [flags]
+## Example: ddev devkit-log --message="Info"\nddev devkit-log --message="Info" --type="info"\nddev devkit-log --message="Success" --type="success"\nddev devkit-log --message="Warning" --type="warning"\nddev devkit-log --message="Error" --type="error"\nddev devkit-log --message="Starting" --type="starting"\nddev devkit-log --message="Completed" --type="completed"
+## Flags: [{"Name":"message","Usage":"Message to log","Type":"string"},{"Name":"type","Usage":"Type of message (info, success, warning, error, starting, completed)","Type":"string"}]
+## Aliases: devkit:log
+
+set -euo pipefail
+
+# Defaults
+MESSAGE=""
+TYPE="info"
+
+# Parse flags
+for ARG in "$@"; do
+  case "$ARG" in
+    --message=*) MESSAGE="${ARG#*=}"; shift; continue ;;
+    --type=*)    TYPE="${ARG#*=}"; shift; continue ;;
+    *) "$0" --message="Unknown flag: $ARG" --type="error"; exit 2 ;;
+  esac
+done
+
+# Validate flags
+[[ -n "$MESSAGE" ]] || { "$0" --message="--message is required." --type="error"; exit 2; }
+
+# Commands
+TYPE_LC="$(printf '%s' "$TYPE" | tr '[:upper:]' '[:lower:]')"
+case "$TYPE_LC" in
+  info|success|warning|error|starting|completed) ;;
+  *)
+    "$0" --message="Unsupported --type '$TYPE'. Allowed: info, success, warning, error, starting, completed." --type="error"
+    exit 2
+    ;;
+esac
+
+LABEL=""
+CLR=""
+RST=$'\033[0m'
+
+case "$TYPE_LC" in
+  info)      LABEL="";            CLR=""          ;;  # uncoloured
+  success)   LABEL="[success]";   CLR=$'\033[32m' ;;  # green
+  warning)   LABEL="[warning]";   CLR=$'\033[33m' ;;  # yellow
+  error)     LABEL="[error]";     CLR=$'\033[31m' ;;  # red
+  starting)  LABEL="[starting]";  CLR=$'\033[36m' ;;  # cyan
+  completed) LABEL="[completed]"; CLR=$'\033[32m' ;;  # green
+esac
+
+if [ "$TYPE_LC" = "info" ]; then
+  PREFIX=""
+else
+  if ! [ -t 2 ] || [ -n "${NO_COLOR:-}" ] || [ "${TERM:-}" = "dumb" ]; then
+    CLR=""
+    RST=""
+  fi
+
+  TS="[$(date '+%Y-%m-%d %H:%M:%S')]"
+  PREFIX="${TS} ${CLR}${LABEL}${RST} "
+fi
+
+while IFS= read -r line || [ -n "$line" ]; do
+  printf '%s%s\n' "$PREFIX" "$line" 1>&2
+done <<< "$MESSAGE"

--- a/commands/host/devkit-log
+++ b/commands/host/devkit-log
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Print a formatted log message.
 ## Usage: devkit-log [flags]
-## Example: ddev devkit-log --message="Info"\nddev devkit-log --message="Info" --type="info"\nddev devkit-log --message="Success" --type="success"\nddev devkit-log --message="Warning" --type="warning"\nddev devkit-log --message="Error" --type="error"\nddev devkit-log --message="Starting" --type="starting"\nddev devkit-log --message="Completed" --type="completed"
+## Example: ddev devkit-log --message="Info" (default type: "info")\nddev devkit-log --message="Info" --type="info"\nddev devkit-log --message="Success" --type="success"\nddev devkit-log --message="Warning" --type="warning"\nddev devkit-log --message="Error" --type="error"\nddev devkit-log --message="Starting" --type="starting"\nddev devkit-log --message="Completed" --type="completed"
 ## Flags: [{"Name":"message","Usage":"Message to log","Type":"string"},{"Name":"type","Usage":"Type of message (info, success, warning, error, starting, completed)","Type":"string"}]
 ## Aliases: devkit:log
 

--- a/commands/host/devkit-log
+++ b/commands/host/devkit-log
@@ -26,7 +26,7 @@ done
 # Validate flags
 [[ -n "$MESSAGE" ]] || { "$0" --message="--message is required." --type="error"; exit 2; }
 
-# Commands
+# Guards
 TYPE_LC="$(printf '%s' "$TYPE" | tr '[:upper:]' '[:lower:]')"
 case "$TYPE_LC" in
   info|success|warning|error|starting|completed) ;;
@@ -36,30 +36,32 @@ case "$TYPE_LC" in
     ;;
 esac
 
-LABEL=""
-CLR=""
-RST=$'\033[0m'
+# Colour palette (ANSI 8-colour)
+CLR_ESC=$'\033'              # escape
+CLR_RESET="${CLR_ESC}[0m"    # reset
+CLR_RED="${CLR_ESC}[31m"     # red
+CLR_GREEN="${CLR_ESC}[32m"   # green
+CLR_YELLOW="${CLR_ESC}[33m"  # yellow
+CLR_MAGENTA="${CLR_ESC}[35m" # magenta
+CLR_CYAN="${CLR_ESC}[36m"    # cyan
 
+# Commands
 case "$TYPE_LC" in
-  info)      LABEL="";            CLR=""          ;;  # uncoloured
-  success)   LABEL="[success]";   CLR=$'\033[32m' ;;  # green
-  warning)   LABEL="[warning]";   CLR=$'\033[33m' ;;  # yellow
-  error)     LABEL="[error]";     CLR=$'\033[31m' ;;  # red
-  starting)  LABEL="[starting]";  CLR=$'\033[36m' ;;  # cyan
-  completed) LABEL="[completed]"; CLR=$'\033[32m' ;;  # green
+  success)   CLR="$CLR_GREEN" ;;
+  warning)   CLR="$CLR_YELLOW" ;;
+  error)     CLR="$CLR_RED" ;;
+  starting)  CLR="$CLR_MAGENTA" ;;
+  completed) CLR="$CLR_CYAN" ;;
+  *)         CLR="" ;;
 esac
 
-if [ "$TYPE_LC" = "info" ]; then
-  PREFIX=""
-else
-  if ! [ -t 2 ] || [ -n "${NO_COLOR:-}" ] || [ "${TERM:-}" = "dumb" ]; then
-    CLR=""
-    RST=""
-  fi
+PREFIX="[$TYPE_LC]"
 
-  TS="[$(date '+%Y-%m-%d %H:%M:%S')]"
-  PREFIX="${TS} ${CLR}${LABEL}${RST} "
+if [ -n "$CLR" ] && [ -t 2 ] && [ -z "${NO_COLOR:-}" ] && [ "${TERM:-}" != "dumb" ]; then
+  PREFIX="${CLR}${PREFIX}${CLR_RESET}"
 fi
+
+PREFIX="[$(date '+%Y-%m-%d %H:%M:%S')] $PREFIX "
 
 while IFS= read -r line || [ -n "$line" ]; do
   printf '%s%s\n' "$PREFIX" "$line" 1>&2

--- a/commands/host/devkit-minio-create-bucket
+++ b/commands/host/devkit-minio-create-bucket
@@ -26,13 +26,13 @@ for ARG in "$@"; do
     --access-key=*) ACCESS_KEY="${ARG#*=}"; shift; continue ;;
     --secret-key=*) SECRET_KEY="${ARG#*=}"; shift; continue ;;
     --host=*)       HOST="${ARG#*=}"; shift; continue ;;
-    *) echo "Unknown flag: $ARG" >&2; exit 2 ;;
+    *) ddev devkit-log --message="Unknown flag: $ARG" --type="error"; exit 2 ;;
   esac
 done
 
 # Validate flags
-[[ -n "$BUCKET" ]] || { echo "--bucket is required." >&2; exit 2; }
-[[ -n "$POLICY" ]] || { echo "--policy is required." >&2; exit 2; }
+[[ -n "$BUCKET" ]] || { ddev devkit-log --message="--bucket is required." --type="error"; exit 2; }
+[[ -n "$POLICY" ]] || { ddev devkit-log --message="--policy is required." --type="error"; exit 2; }
 
 # Helpers
 mc_exec() {
@@ -44,13 +44,13 @@ mc_exec alias set localminio "$HOST" "$ACCESS_KEY" "$SECRET_KEY" > /dev/null
 
 # Guards
 if mc_exec ls localminio | grep -q "^.* $BUCKET/"; then
-  echo "MinIO bucket '$BUCKET' already exists. Nothing to do." >&2
+  ddev devkit-log --message="MinIO bucket '$BUCKET' already exists. Nothing to do." --type="success"
   exit 0
 fi
 
 # Commands
-echo "Creating MinIO bucket '$BUCKET'..." >&2
+ddev devkit-log --message="Creating MinIO bucket '$BUCKET'..."
 mc_exec mb "localminio/$BUCKET" > /dev/null
 
-echo "Setting policy '$POLICY' on MinIO bucket '$BUCKET'..." >&2
+ddev devkit-log --message="Setting policy '$POLICY' on MinIO bucket '$BUCKET'..."
 mc_exec anonymous set public "localminio/$BUCKET" > /dev/null

--- a/commands/host/devkit-minio-create-bucket
+++ b/commands/host/devkit-minio-create-bucket
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Create a MinIO bucket if it does not exist, and set its policy.
 ## Usage: devkit-minio-create-bucket [flags]
-## Example: ddev devkit-minio-create-bucket --bucket=example --policy=public
+## Example: ddev devkit-minio-create-bucket --bucket="example" --policy="public"
 ## Flags: [{"Name":"bucket","Usage":"Name of the bucket to create","Type":"string"},{"Name":"policy","Usage":"Policy to set on the bucket","Type":"string"},{"Name":"access-key","Usage":"Access key for MinIO","Type":"string"},{"Name":"secret-key","Usage":"Secret key for MinIO","Type":"string"},{"Name":"host","Usage":"Host URL for MinIO","Type":"string"}]
 ## Aliases: devkit:minio:create:bucket,devkit-minio-bucket-create,devkit:minio:bucket:create
 

--- a/commands/host/devkit-minio-create-bucket
+++ b/commands/host/devkit-minio-create-bucket
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Create a MinIO bucket if it does not exist, and set its policy.
 ## Usage: devkit-minio-create-bucket [flags]
-## Example: ddev devkit-minio-create-bucket --bucket="example" --policy="public"
+## Example: ddev devkit-minio-create-bucket --bucket="example" --policy="public" (default access-key: "ddevminio", secret-key: "ddevminio", host: "DDEV_PRIMARY_URL_WITHOUT_PORT:10101")
 ## Flags: [{"Name":"bucket","Usage":"Name of the bucket to create","Type":"string"},{"Name":"policy","Usage":"Policy to set on the bucket","Type":"string"},{"Name":"access-key","Usage":"Access key for MinIO","Type":"string"},{"Name":"secret-key","Usage":"Secret key for MinIO","Type":"string"},{"Name":"host","Usage":"Host URL for MinIO","Type":"string"}]
 ## Aliases: devkit:minio:create:bucket,devkit-minio-bucket-create,devkit:minio:bucket:create
 

--- a/commands/host/devkit-minio-create-bucket
+++ b/commands/host/devkit-minio-create-bucket
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Create a MinIO bucket if it does not exist, and set its policy.
 ## Usage: devkit-minio-create-bucket [flags]
-## Example: "ddev devkit-minio-create-bucket --bucket=example --policy=public"
+## Example: ddev devkit-minio-create-bucket --bucket=example --policy=public
 ## Flags: [{"Name":"bucket","Usage":"Name of the bucket to create","Type":"string"},{"Name":"policy","Usage":"Policy to set on the bucket","Type":"string"},{"Name":"access-key","Usage":"Access key for MinIO","Type":"string"},{"Name":"secret-key","Usage":"Secret key for MinIO","Type":"string"},{"Name":"host","Usage":"Host URL for MinIO","Type":"string"}]
 ## Aliases: devkit:minio:create:bucket,devkit-minio-bucket-create,devkit:minio:bucket:create
 

--- a/commands/host/devkit-script-run
+++ b/commands/host/devkit-script-run
@@ -30,7 +30,7 @@ done
 [[ -n "$LOCATION" ]] || { ddev devkit-log --message="--location is required." --type="error"; exit 2; }
 
 # Guards
-if [[ "$LOCATION" == host ]]; then
+if [[ "$LOCATION" == "host" ]]; then
   SCRIPT_PATH="$DDEV_APPROOT/$SCRIPT"
 
   if [[ -d "$SCRIPT_PATH" ]]; then

--- a/commands/host/devkit-script-run
+++ b/commands/host/devkit-script-run
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Run a script on the host or in a specified service.
 ## Usage: devkit-script-run [flags] -- [script-args]
-## Example: "ddev devkit-script-run --script=scripts/example.sh --location=web -- script-arg1 script-arg2"
+## Example: ddev devkit-script-run --script=scripts/example.sh --location=web -- script-arg1 script-arg2
 ## Flags: [{"Name":"script","Usage":"Path to the script to run, relative to the project root","Type":"string"},{"Name":"location","Usage":"Where to run the script: 'host' or a service name such as 'web'","Type":"string"}]
 ## Aliases: devkit:script:run,devkit-run-script,devkit:run:script
 

--- a/commands/host/devkit-script-run
+++ b/commands/host/devkit-script-run
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Run a script on the host or in a specified service.
 ## Usage: devkit-script-run [flags] -- [script-args]
-## Example: ddev devkit-script-run --script=scripts/example.sh --location=web -- script-arg1 script-arg2
+## Example: ddev devkit-script-run --script="scripts/example.sh" --location="web" -- script-arg1 script-arg2
 ## Flags: [{"Name":"script","Usage":"Path to the script to run, relative to the project root","Type":"string"},{"Name":"location","Usage":"Where to run the script: 'host' or a service name such as 'web'","Type":"string"}]
 ## Aliases: devkit:script:run,devkit-run-script,devkit:run:script
 

--- a/commands/host/devkit-script-run
+++ b/commands/host/devkit-script-run
@@ -21,53 +21,48 @@ for ARG in "$@"; do
     --script=*)   SCRIPT="${ARG#*=}"; shift; continue ;;
     --location=*) LOCATION="${ARG#*=}"; shift; continue ;;
     --) shift; break ;;
-    *) echo "Unknown flag: $ARG" >&2; exit 2 ;;
+    *) ddev devkit-log --message="Unknown flag: $ARG" --type="error"; exit 2 ;;
   esac
 done
 
 # Validate flags
-[[ -n "$SCRIPT" ]]   || { echo "--script is required." >&2; exit 2; }
-[[ -n "$LOCATION" ]] || { echo "--location is required." >&2; exit 2; }
+[[ -n "$SCRIPT" ]]   || { ddev devkit-log --message="--script is required." --type="error"; exit 2; }
+[[ -n "$LOCATION" ]] || { ddev devkit-log --message="--location is required." --type="error"; exit 2; }
 
 # Guards
 if [[ "$LOCATION" == host ]]; then
   SCRIPT_PATH="$DDEV_APPROOT/$SCRIPT"
 
   if [[ -d "$SCRIPT_PATH" ]]; then
-    echo "'$SCRIPT_PATH' is a directory. Refusing to run." >&2
+    ddev devkit-log --message="'$SCRIPT_PATH' is a directory. Refusing to run." --type="error"
     exit 1
   fi
 
   if [[ ! -f "$SCRIPT_PATH" ]]; then
-    echo "'$SCRIPT_PATH' not found. Cannot run." >&2
+    ddev devkit-log --message="'$SCRIPT_PATH' not found. Cannot run." --type="error"
     exit 1
   fi
 else
   SCRIPT_PATH="$SCRIPT"
 
   if ! ddev exec -s "$LOCATION" bash -lc 'true' >/dev/null 2>&1; then
-    echo "Service '$LOCATION' not found or not running." >&2
+    ddev devkit-log --message="Service '$LOCATION' not found or not running." --type="error"
     exit 1
   fi
 
   if ddev exec -s "$LOCATION" bash -lc "test -d $SCRIPT_PATH" >/dev/null 2>&1; then
-    echo "'$SCRIPT_PATH' is a directory. Refusing to run." >&2
+    ddev devkit-log --message="'$SCRIPT_PATH' is a directory. Refusing to run." --type="error"
     exit 1
   fi
 
   if ! ddev exec -s "$LOCATION" bash -lc "test -f $SCRIPT_PATH" >/dev/null 2>&1; then
-    echo "'$SCRIPT_PATH' not found. Cannot run." >&2
+    ddev devkit-log --message="'$SCRIPT_PATH' not found. Cannot run." --type="error"
     exit 1
   fi
 fi
 
-# Helpers
-timestamp() {
-  date '+%Y-%m-%d %H:%M:%S'
-}
-
 # Commands
-echo "[$(timestamp)] Starting script '$SCRIPT' in '$LOCATION'..." >&2
+ddev devkit-log --message="Running script '$SCRIPT' in '$LOCATION'." --type="starting"
 
 if [[ "$LOCATION" == "host" ]]; then
   bash "$SCRIPT_PATH" "$@"
@@ -75,4 +70,4 @@ else
   ddev exec -s "$LOCATION" bash "$SCRIPT_PATH" "$@"
 fi
 
-echo "[$(timestamp)] Completed script '$SCRIPT' in '$LOCATION'." >&2
+ddev devkit-log --message="Running script '$SCRIPT' in '$LOCATION'." --type="completed"

--- a/commands/host/site-auth
+++ b/commands/host/site-auth
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Authentication tasks.
 ## Usage: site-auth
-## Example: "ddev site-auth"
+## Example: ddev site-auth
 ## Aliases: site:auth,site-authentication,site:authentication
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-auth
+++ b/commands/host/site-auth
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-auth.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-auth.sh" --location="host"

--- a/commands/host/site-build
+++ b/commands/host/site-build
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Build tasks.
 ## Usage: site-build
-## Example: "ddev site-build"
+## Example: ddev site-build
 ## Aliases: site:build
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-build
+++ b/commands/host/site-build
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-build.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-build.sh" --location="host"

--- a/commands/host/site-build-backend
+++ b/commands/host/site-build-backend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-build-backend.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-build-backend.sh" --location="host"

--- a/commands/host/site-build-backend
+++ b/commands/host/site-build-backend
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Backend build tasks.
 ## Usage: site-build-backend
-## Example: "ddev site-build-backend"
+## Example: ddev site-build-backend
 ## Aliases: site:build:backend,site-build-be,site:build:be,site-backend-build,site:backend:build,site-be-build,site:be:build
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-build-frontend
+++ b/commands/host/site-build-frontend
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Frontend build tasks.
 ## Usage: site-build-frontend
-## Example: "ddev site-build-frontend"
+## Example: ddev site-build-frontend
 ## Aliases: site:build:frontend,site-build-fe,site:build:fe,site-frontend-build,site:frontend:build,site-fe-build,site:fe:build
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-build-frontend
+++ b/commands/host/site-build-frontend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-build-frontend.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-build-frontend.sh" --location="host"

--- a/commands/host/site-install
+++ b/commands/host/site-install
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Installation tasks.
 ## Usage: site-install
-## Example: "ddev site-install"
+## Example: ddev site-install
 ## Aliases: site:install,site-installation,site:installation
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-install
+++ b/commands/host/site-install
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-install.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-install.sh" --location="host"

--- a/commands/host/site-install-backend
+++ b/commands/host/site-install-backend
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Backend installation tasks.
 ## Usage: site-install-backend
-## Example: "ddev site-install-backend"
+## Example: ddev site-install-backend
 ## Aliases: site:install:backend,site-install-be,site:install:be,site-backend-install,site:backend:install,site-be-install,site:be:install
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-install-backend
+++ b/commands/host/site-install-backend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-install-backend.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-install-backend.sh" --location="host"

--- a/commands/host/site-install-frontend
+++ b/commands/host/site-install-frontend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-install-frontend.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-install-frontend.sh" --location="host"

--- a/commands/host/site-install-frontend
+++ b/commands/host/site-install-frontend
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Frontend installation tasks.
 ## Usage: site-install-frontend
-## Example: "ddev site-install-frontend"
+## Example: ddev site-install-frontend
 ## Aliases: site:install:frontend,site-install-fe,site:install:fe,site-frontend-install,site:frontend:install,site-fe-install,site:fe:install
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-mode-development
+++ b/commands/host/site-mode-development
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-mode-development.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-mode-development.sh" --location="host"

--- a/commands/host/site-mode-development
+++ b/commands/host/site-mode-development
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Enable development mode.
 ## Usage: site-mode-development
-## Example: "ddev site-mode-development"
+## Example: ddev site-mode-development
 ## Aliases: site:mode:development,site-mode-dev,site:mode:dev,site-development-mode,site:development:mode,site-dev-mode,site:dev:mode
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-mode-production
+++ b/commands/host/site-mode-production
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Enable production mode.
 ## Usage: site-mode-production
-## Example: "ddev site-mode-production"
+## Example: ddev site-mode-production
 ## Aliases: site:mode:production,site-mode-prod,site:mode:prod,site-production-mode,site:production:mode,site-prod-mode,site:prod:mode
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-mode-production
+++ b/commands/host/site-mode-production
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-mode-production.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-mode-production.sh" --location="host"

--- a/commands/host/site-scaffold
+++ b/commands/host/site-scaffold
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Scaffolding tasks.
 ## Usage: site-scaffold
-## Example: "ddev site-scaffold"
+## Example: ddev site-scaffold
 ## Aliases: site:scaffold,site-scaffolding,site:scaffolding,site-scaff,site:scaff
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-scaffold
+++ b/commands/host/site-scaffold
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-scaffold.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-scaffold.sh" --location="host"

--- a/commands/host/site-sync
+++ b/commands/host/site-sync
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-sync.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-sync.sh" --location="host"

--- a/commands/host/site-sync
+++ b/commands/host/site-sync
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Synchronisation tasks.
 ## Usage: site-sync
-## Example: "ddev site-sync"
+## Example: ddev site-sync
 ## Aliases: site:sync
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-sync-backend
+++ b/commands/host/site-sync-backend
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Backend synchronisation tasks.
 ## Usage: site-sync-backend
-## Example: "ddev site-sync-backend"
+## Example: ddev site-sync-backend
 ## Aliases: site:sync:backend,site-sync-be,site:sync:be,site-backend-sync,site:backend:sync,site-be-sync,site:be:sync
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-sync-backend
+++ b/commands/host/site-sync-backend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-sync-backend.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-sync-backend.sh" --location="host"

--- a/commands/host/site-sync-frontend
+++ b/commands/host/site-sync-frontend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-sync-frontend.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-sync-frontend.sh" --location="host"

--- a/commands/host/site-sync-frontend
+++ b/commands/host/site-sync-frontend
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Frontend synchronisation tasks.
 ## Usage: site-sync-frontend
-## Example: "ddev site-sync-frontend"
+## Example: ddev site-sync-frontend
 ## Aliases: site:sync:frontend,site-sync-fe,site:sync:fe,site-frontend-sync,site:frontend:sync,site-fe-sync,site:fe:sync
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-test
+++ b/commands/host/site-test
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Testing tasks.
 ## Usage: site-test
-## Example: "ddev site-test"
+## Example: ddev site-test
 ## Aliases: site:test
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-test
+++ b/commands/host/site-test
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-test.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-test.sh" --location="host"

--- a/commands/host/site-test-backend
+++ b/commands/host/site-test-backend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-test-backend.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-test-backend.sh" --location="host"

--- a/commands/host/site-test-backend
+++ b/commands/host/site-test-backend
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Backend testing tasks.
 ## Usage: site-test-backend
-## Example: "ddev site-test-backend"
+## Example: ddev site-test-backend
 ## Aliases: site:test:backend,site-test-be,site:test:be,site-backend-test,site:backend:test,site-be-test,site:be:test
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-test-frontend
+++ b/commands/host/site-test-frontend
@@ -4,7 +4,7 @@
 ## Command provided by https://github.com/colinstillwell/ddev-site-devkit
 ## Description: Frontend testing tasks.
 ## Usage: site-test-frontend
-## Example: "ddev site-test-frontend"
+## Example: ddev site-test-frontend
 ## Aliases: site:test:frontend,site-test-fe,site:test:fe,site-frontend-test,site:frontend:test,site-fe-test,site:fe:test
 
 # Exit on error; treat unset variables as errors; fail pipelines if any command fails

--- a/commands/host/site-test-frontend
+++ b/commands/host/site-test-frontend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-test-frontend.sh" --location=host
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-test-frontend.sh" --location="host"

--- a/install.yaml
+++ b/install.yaml
@@ -5,6 +5,7 @@ project_files:
   - commands/host/devkit-config-get
   - commands/host/devkit-db-import
   - commands/host/devkit-file-copy
+  - commands/host/devkit-log
   - commands/host/devkit-minio-create-bucket
   - commands/host/devkit-script-run
   - commands/host/site-auth

--- a/site-devkit/site/scripts/site-build.sh
+++ b/site-devkit/site/scripts/site-build.sh
@@ -14,9 +14,9 @@ https://github.com/colinstillwell/ddev-site-devkit#customising-the-generated-scr
 EXAMPLE
 
 # Run backend build tasks
-# echo "Running backend build tasks..."
+# ddev devkit-log --message="Running backend build tasks..."
 # ddev site-build-backend
 
 # Run frontend build tasks
-# echo "Running frontend build tasks..."
+# ddev devkit-log --message="Running frontend build tasks..."
 # ddev site-build-frontend

--- a/site-devkit/site/scripts/site-install-backend.sh
+++ b/site-devkit/site/scripts/site-install-backend.sh
@@ -14,9 +14,9 @@ https://github.com/colinstillwell/ddev-site-devkit#customising-the-generated-scr
 EXAMPLE
 
 # Run backend build tasks
-# echo "Running backend build tasks..."
+# ddev devkit-log --message="Running backend build tasks..."
 # ddev site-build-backend
 
 # Run backend synchronisation tasks
-# echo "Running backend synchronisation tasks..."
+# ddev devkit-log --message="Running backend synchronisation tasks..."
 # ddev site-sync-backend

--- a/site-devkit/site/scripts/site-install-frontend.sh
+++ b/site-devkit/site/scripts/site-install-frontend.sh
@@ -14,9 +14,9 @@ https://github.com/colinstillwell/ddev-site-devkit#customising-the-generated-scr
 EXAMPLE
 
 # Run frontend build tasks
-# echo "Running frontend build tasks..."
+# ddev devkit-log --message="Running frontend build tasks..."
 # ddev site-build-frontend
 
 # Run frontend synchronisation tasks
-# echo "Running frontend synchronisation tasks..."
+# ddev devkit-log --message="Running frontend synchronisation tasks..."
 # ddev site-sync-frontend

--- a/site-devkit/site/scripts/site-install.sh
+++ b/site-devkit/site/scripts/site-install.sh
@@ -14,9 +14,9 @@ https://github.com/colinstillwell/ddev-site-devkit#customising-the-generated-scr
 EXAMPLE
 
 # Run backend installation tasks
-# echo "Running backend installation tasks..."
+# ddev devkit-log --message="Running backend installation tasks..."
 # ddev site-install-backend
 
 # Run frontend installation tasks
-# echo "Running frontend installation tasks..."
+# ddev devkit-log --message="Running frontend installation tasks..."
 # ddev site-install-frontend

--- a/site-devkit/site/scripts/site-sync.sh
+++ b/site-devkit/site/scripts/site-sync.sh
@@ -14,9 +14,9 @@ https://github.com/colinstillwell/ddev-site-devkit#customising-the-generated-scr
 EXAMPLE
 
 # Run backend synchronisation tasks
-# echo "Running backend synchronisation tasks..."
+# ddev devkit-log --message="Running backend synchronisation tasks..."
 # ddev site-sync-backend
 
 # Run frontend synchronisation tasks
-# echo "Running frontend synchronisation tasks..."
+# ddev devkit-log --message="Running frontend synchronisation tasks..."
 # ddev site-sync-frontend

--- a/site-devkit/site/scripts/site-test.sh
+++ b/site-devkit/site/scripts/site-test.sh
@@ -14,9 +14,9 @@ https://github.com/colinstillwell/ddev-site-devkit#customising-the-generated-scr
 EXAMPLE
 
 # Run backend testing tasks
-# echo "Running backend testing tasks..."
+# ddev devkit-log --message="Running backend testing tasks..."
 # ddev site-test-backend
 
 # Run frontend testing tasks
-# echo "Running frontend testing tasks..."
+# ddev devkit-log --message="Running frontend testing tasks..."
 # ddev site-test-frontend


### PR DESCRIPTION
## The Issue

- Fixes #9

New devkit command for handing errors and logging.

## How This PR Solves The Issue

1. Created a new `devkit-log` command.
2. Updated the README.
3. Updated the `install.yaml`.
4. Replace `echo` calls everywhere within the add-on to use `devkit-log`.
5. Improved examples whilst I was here.
6. Coding standards whilst I was here for consistency where possible.

## Release/Deployment Notes

1. Introduced a new `devkit-log` command.
2. Updated examples.
