### PR TITLE
[60] 

### DIFF
--- a/commands/host/devkit-minio-create-bucket
+++ b/commands/host/devkit-minio-create-bucket
@@ -53,4 +53,4 @@ ddev devkit-log --message="Creating MinIO bucket '$BUCKET'..."
 mc_exec mb "localminio/$BUCKET" > /dev/null
 
 ddev devkit-log --message="Setting policy '$POLICY' on MinIO bucket '$BUCKET'..."
-mc_exec anonymous set public "localminio/$BUCKET" > /dev/null
+mc_exec anonymous set $POLICY "localminio/$BUCKET" > /dev/null


### PR DESCRIPTION
## The Issue

- Fixes #60

devkit-minio-create-bucket is always creating as public

## How This PR Solves The Issue

1. Updated `devkit-minio-create-bucket` to respect the `--policy` flag.

## Release/Deployment Notes

1. `devkit-minio-create-bucket` nows respects the `--policy` flag.
