### PR TITLE
[64] Add optional --default fallback to devkit-config-get

### DIFF
--- a/commands/host/devkit-config-get
+++ b/commands/host/devkit-config-get
@@ -40,7 +40,7 @@ if [[ "$FORMAT" != "env" ]]; then
 fi
 
 # Commands
-VALUE="$(ddev exec -s "$LOCATION" bash -lc "printenv $(printf '%q' "$NAME")" 2>/dev/null || true)"
+VALUE="$(ddev exec -s "$LOCATION" printenv "$NAME" 2>/dev/null || true)"
 
 if [[ -z "$VALUE" ]]; then
   if [[ -n "$DEFAULT" ]]; then


### PR DESCRIPTION
## The Issue

- Fixes #64

Add optional `--default` fallback to devkit-config-get.

## How This PR Solves The Issue

1. Added the flag.

## Release/Deployment Notes

1. Added an optional `--default` fallback to `devkit-config-get`.
