### PR TITLE
[63] devkit-config-get is not checking whether the service is available

### DIFF
--- a/commands/host/devkit-config-get
+++ b/commands/host/devkit-config-get
@@ -39,6 +39,13 @@ if [[ "$FORMAT" != "env" ]]; then
   exit 2
 fi
 
+if [[ "$LOCATION" != "host" ]]; then
+  if ! ddev exec -s "$LOCATION" bash -lc 'true' >/dev/null 2>&1; then
+    ddev devkit-log --message="Service '$LOCATION' not found or not running." --type="error"
+    exit 1
+  fi
+fi
+
 # Commands
 VALUE="$(ddev exec -s "$LOCATION" printenv "$NAME" 2>/dev/null || true)"
 


### PR DESCRIPTION
## The Issue

- Fixes #63

`devkit-config-get` is not checking whether the service is available.

## How This PR Solves The Issue

1. Added a check for `devkit-config-get` to make sure the service is available.

## Release/Deployment Notes

1. Added a check for `devkit-config-get` to make sure the service is available.
