### PR TITLE
[68] Make database import optional by allowing “0” to skip in devkit-db-import

### DIFF
--- a/commands/host/devkit-db-import
+++ b/commands/host/devkit-db-import
@@ -64,15 +64,22 @@ for i in "${!FILES[@]}"; do
 done
 
 while true; do
-  printf "Enter a number 1-%d: " "${#FILES[@]}" >&2
+  printf "Enter a number 1-%d (0 to skip): " "${#FILES[@]}" >&2
   read -r n
-  if [[ "$n" =~ ^[0-9]+$ ]] && (( n>=1 && n<=${#FILES[@]} )); then
-    CHOICE="${FILES[$((n-1))]}"
-    break
+
+  if [[ "$n" =~ ^[0-9]+$ ]]; then
+    if (( n==0 )); then
+      ddev devkit-log --message="Database import skipped." --type="warning"
+      exit 0
+    elif (( n>=1 && n<=${#FILES[@]} )); then
+      CHOICE="${FILES[$((n-1))]}"
+      break
+    fi
   fi
+
   ddev devkit-log --message="Invalid selection. Please try again." --type="error"
 done
 
 # Commands
-ddev devkit-log --message="Importing dump file '$(basename -- "$CHOICE")'..."
+ddev devkit-log --message="Importing database dump file '$(basename -- "$CHOICE")'..."
 exec ddev import-db -f "$CHOICE"


### PR DESCRIPTION
## The Issue

- Fixes #68

Make database import optional by allowing "0" to skip in `devkit-db-import`.

## How This PR Solves The Issue

Allowed the user to skip the import step by entering `0` at the selection prompt. The command logs a message indicating the import was skipped and exits cleanly without error.

## Release/Deployment Notes

`devkit-db-import` now has the option of "0" to skip the import.
