### PR TITLE
[70] Create a devkit command for deleting typesense collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,16 @@ There are two types of commands provided by this add-on:
 
 ### `ddev devkit-*` commands
 
-| Command                      | Description                                                                              |
-| ---------------------------- | ---------------------------------------------------------------------------------------- |
-| `devkit-config-diff`         | Compare config and report keys present in reference but missing in target                |
-| `devkit-config-get`          | Get a config value by name from a given format and location                              |
-| `devkit-db-import`           | Interactively import an SQL dump into the project database                               |
-| `devkit-file-copy`           | Copy a file from source to destination within the project, skipping if it already exists |
-| `devkit-log`                 | Print a formatted log message                                                            |
-| `devkit-minio-create-bucket` | Create a MinIO bucket if it does not exist, and set its policy                           |
-| `devkit-script-run`          | Run a script on the host or in a specified service                                       |
+| Command                               | Description                                                                              |
+| ------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `devkit-config-diff`                  | Compare config and report keys present in reference but missing in target                |
+| `devkit-config-get`                   | Get a config value by name from a given format and location                              |
+| `devkit-db-import`                    | Interactively import an SQL dump into the project database                               |
+| `devkit-file-copy`                    | Copy a file from source to destination within the project, skipping if it already exists |
+| `devkit-log`                          | Print a formatted log message                                                            |
+| `devkit-minio-create-bucket`          | Create a MinIO bucket if it does not exist, and set its policy                           |
+| `devkit-script-run`                   | Run a script on the host or in a specified service                                       |
+| `devkit-typesense-delete-collections` | Delete Typesense collections                                                             |
 
 ### `ddev site-*` commands
 

--- a/commands/host/devkit-typesense-delete-collections
+++ b/commands/host/devkit-typesense-delete-collections
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/colinstillwell/ddev-site-devkit
+## Description: Delete Typesense collections.
+## Usage: devkit-typesense-delete-collections [flags]
+## Example: ddev devkit-typesense-delete-collections (default api-key: "ddev", host: "http://typesense:8108")
+## Flags: [{"Name":"api-key","Usage":"API key for Typesense","Type":"string"},{"Name":"host","Usage":"Host URL for Typesense","Type":"string"}]
+## Aliases: devkit:typesense:delete:collections,devkit-typesense-collections-delete,devkit:typesense:collections:delete
+
+# Exit on error; treat unset variables as errors; fail pipelines if any command fails
+set -euo pipefail
+
+# Defaults
+API_KEY="ddev"
+HOST="http://typesense:8108"
+
+# Parse flags
+for ARG in "$@"; do
+  case "$ARG" in
+    --api-key=*) API_KEY="${ARG#*=}"; shift; continue ;;
+    --host=*)    HOST="${ARG#*=}"; shift; continue ;;
+    *) ddev devkit-log --message="Unknown flag: $ARG" --type="error"; exit 2 ;;
+  esac
+done
+
+# Helpers
+web_exec() {
+  ddev exec -s web bash -lc "$*"
+}
+
+# Guards
+if ! ddev exec -s web bash -lc 'true' > /dev/null 2>&1; then
+  ddev devkit-log --message="Service 'web' not found or not running." --type="error"
+  exit 1
+fi
+
+# Commands
+ddev devkit-log --message="Fetching list of collections from Typesense..."
+COLLECTIONS="$(web_exec "curl -sS -H 'X-TYPESENSE-API-KEY: $API_KEY' '$HOST/collections'" | jq -r '.[].name')"
+
+if [ -z "$COLLECTIONS" ]; then
+  ddev devkit-log --message="No collections found in Typesense. Nothing to do." --type="success"
+  exit 0
+fi
+
+for COLLECTION in $COLLECTIONS; do
+  ddev devkit-log --message="Deleting collection '$COLLECTION'..."
+
+  HTTP_CODE="$(web_exec "curl -sS -o /dev/null -w '%{http_code}' -X DELETE -H 'X-TYPESENSE-API-KEY: $API_KEY' '$HOST/collections/$COLLECTION'")"
+
+  if [[ "$HTTP_CODE" =~ ^2[0-9]{2}$ ]]; then
+    ddev devkit-log --message="Deleted '$COLLECTION'." --type="success"
+  else
+    ddev devkit-log --message="Failed to delete '$COLLECTION'." --type="error"
+  fi
+done

--- a/install.yaml
+++ b/install.yaml
@@ -8,6 +8,7 @@ project_files:
   - commands/host/devkit-log
   - commands/host/devkit-minio-create-bucket
   - commands/host/devkit-script-run
+  - commands/host/devkit-typesense-delete-collections
   - commands/host/site-auth
   - commands/host/site-build
   - commands/host/site-build-backend


### PR DESCRIPTION
## The Issue

- Fixes #70

Create a devkit command for deleting typesense collections.

## How This PR Solves The Issue

1. Created a new `devkit-typesense-delete-collections` command.

## Release/Deployment Notes

A new `devkit-typesense-delete-collections` command is now available.
