### PR TITLE
[71] Create a devkit command for indexing Drupal search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ There are two types of commands provided by this add-on:
 | `devkit-config-diff`                  | Compare config and report keys present in reference but missing in target                |
 | `devkit-config-get`                   | Get a config value by name from a given format and location                              |
 | `devkit-db-import`                    | Interactively import an SQL dump into the project database                               |
+| `devkit-drupal-search-api-index`      | Index Drupal Search API indexes for a given server                                       |
 | `devkit-file-copy`                    | Copy a file from source to destination within the project, skipping if it already exists |
 | `devkit-log`                          | Print a formatted log message                                                            |
 | `devkit-minio-create-bucket`          | Create a MinIO bucket if it does not exist, and set its policy                           |

--- a/commands/host/devkit-drupal-search-api-index
+++ b/commands/host/devkit-drupal-search-api-index
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Command provided by https://github.com/colinstillwell/ddev-site-devkit
+## Description: Index Drupal Search API indexes for a given server.
+## Usage: devkit-drupal-search-api-index [flags]
+## Example: ddev devkit-drupal-search-api-index --server-name="Typesense" (default batch-size: 500)
+## Flags: [{"Name":"server-name","Usage":"Search API server name to target","Type":"string"},{"Name":"batch-size","Usage":"Batch size for indexing","Type":"string"}]
+## Aliases: devkit:drupal:search:api:index
+
+# Exit on error; treat unset variables as errors; fail pipelines if any command fails
+set -euo pipefail
+
+# Defaults
+SERVER_NAME=""
+BATCH_SIZE="500"
+
+# Parse flags
+for ARG in "$@"; do
+  case "$ARG" in
+    --server-name=*) SERVER_NAME="${ARG#*=}"; shift; continue ;;
+    --batch-size=*)  BATCH_SIZE="${ARG#*=}"; shift; continue ;;
+    *) ddev devkit-log --message="Unknown flag: $ARG" --type="error"; exit 2 ;;
+  esac
+done
+
+# Validate flags
+[[ -n "$SERVER_NAME" ]] || { ddev devkit-log --message="--server-name is required." --type="error"; exit 2; }
+
+# Helpers
+web_exec() {
+  ddev exec -s web bash -lc "$*"
+}
+
+# Guards
+if ! ddev exec -s web bash -lc 'true' > /dev/null 2>&1; then
+  ddev devkit-log --message="Service 'web' not found or not running." --type="error"
+  exit 1
+fi
+
+# Commands
+ddev devkit-log --message="Fetching list of Search API indexes for server '$SERVER_NAME'..."
+
+INDEX_IDS="$(web_exec "drush search-api:list --format=json" | jq -r --arg srv "$SERVER_NAME" '.[] | select(.serverName == $srv) | .id')"
+
+if [ -z "$INDEX_IDS" ]; then
+  ddev devkit-log --message="No Search API indexes found for server '$SERVER_NAME'." --type="warning"
+  exit 0
+fi
+
+for INDEX_ID in $INDEX_IDS; do
+  ddev devkit-log --message="Marking '$INDEX_ID' for reindexing..."
+  web_exec "drush -y search-api:reset-tracker '$INDEX_ID'"
+
+  ddev devkit-log --message="Reindexing '$INDEX_ID'..."
+  web_exec "drush -y search-api:index '$INDEX_ID'  --batch-size='$BATCH_SIZE'"
+done

--- a/install.yaml
+++ b/install.yaml
@@ -4,6 +4,7 @@ project_files:
   - commands/host/devkit-config-diff
   - commands/host/devkit-config-get
   - commands/host/devkit-db-import
+  - commands/host/devkit-drupal-search-api-index
   - commands/host/devkit-file-copy
   - commands/host/devkit-log
   - commands/host/devkit-minio-create-bucket


### PR DESCRIPTION
## The Issue

- Fixes #71 

Create a devkit command for indexing Drupal search API.

## How This PR Solves The Issue

1. Created a new `devkit-drupal-search-api-index` command for indexing Drupal search API.

## Release/Deployment Notes

There is a new `devkit-drupal-search-api-index` command for indexing Drupal search API.
