### PR TITLE
[81] site commands should respect additional args

### DIFF
--- a/commands/host/site-auth
+++ b/commands/host/site-auth
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-auth.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-auth.sh" --location="host" -- "$@"

--- a/commands/host/site-build
+++ b/commands/host/site-build
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-build.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-build.sh" --location="host" -- "$@"

--- a/commands/host/site-build-backend
+++ b/commands/host/site-build-backend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-build-backend.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-build-backend.sh" --location="host" -- "$@"

--- a/commands/host/site-build-frontend
+++ b/commands/host/site-build-frontend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-build-frontend.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-build-frontend.sh" --location="host" -- "$@"

--- a/commands/host/site-install
+++ b/commands/host/site-install
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-install.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-install.sh" --location="host" -- "$@"

--- a/commands/host/site-install-backend
+++ b/commands/host/site-install-backend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-install-backend.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-install-backend.sh" --location="host" -- "$@"

--- a/commands/host/site-install-frontend
+++ b/commands/host/site-install-frontend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-install-frontend.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-install-frontend.sh" --location="host" -- "$@"

--- a/commands/host/site-mode-development
+++ b/commands/host/site-mode-development
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-mode-development.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-mode-development.sh" --location="host" -- "$@"

--- a/commands/host/site-mode-production
+++ b/commands/host/site-mode-production
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-mode-production.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-mode-production.sh" --location="host" -- "$@"

--- a/commands/host/site-scaffold
+++ b/commands/host/site-scaffold
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-scaffold.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-scaffold.sh" --location="host" -- "$@"

--- a/commands/host/site-sync
+++ b/commands/host/site-sync
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-sync.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-sync.sh" --location="host" -- "$@"

--- a/commands/host/site-sync-backend
+++ b/commands/host/site-sync-backend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-sync-backend.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-sync-backend.sh" --location="host" -- "$@"

--- a/commands/host/site-sync-frontend
+++ b/commands/host/site-sync-frontend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-sync-frontend.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-sync-frontend.sh" --location="host" -- "$@"

--- a/commands/host/site-test
+++ b/commands/host/site-test
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-test.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-test.sh" --location="host" -- "$@"

--- a/commands/host/site-test-backend
+++ b/commands/host/site-test-backend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-test-backend.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-test-backend.sh" --location="host" -- "$@"

--- a/commands/host/site-test-frontend
+++ b/commands/host/site-test-frontend
@@ -11,4 +11,4 @@
 set -euo pipefail
 
 # Run the script
-ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-test-frontend.sh" --location="host"
+ddev devkit-script-run --script=".ddev/site-devkit/site/scripts/site-test-frontend.sh" --location="host" -- "$@"


### PR DESCRIPTION
## The Issue

- Fixes #81

site commands should respect additional args.

## How This PR Solves The Issue

When running `ddev devkit-script-run` it now includes  ` -- "$@"` at the end.

## Release/Deployment Notes

`site-*` commands now allow you to include your own additional args, so that they can be used within the respective `site-*` scripts.
